### PR TITLE
高度な数式環境 (align/gather/split/multiline/cases/matrix) の実装 (#25)

### DIFF
--- a/crates/document/src/block.rs
+++ b/crates/document/src/block.rs
@@ -139,18 +139,29 @@ pub enum DocNode {
     items: Vec<ListItem>,
   },
 
-  /// ディスプレイ数式環境（`equation` / `align` / `gather` / `cases` / `matrix`）
+  /// ディスプレイ数式環境（`equation` / `align` / `gather` / `split` / `multiline` / `cases` / `matrix`）
   ///
   /// Parser が環境種別を `kind` に決め、本体を `\\` で行・`&` で列に分割して `rows` に
-  /// 格納する（env body は math モードで構造化される）。採番される環境では各行の
-  /// `number` に `CounterRegistry::increment(CounterName::Equation)` で発番された通し番号
-  /// （`format` テンプレ適用済みの文字列）が入り、lowering 層が `EquationStyle::number_format`
-  /// でさらに装飾する。`kind` に応じて lowering 以降が列整列・区切り括弧・中央寄せを決める。
+  /// 格納する（env body は math モードで構造化される）。採番には 2 つの粒度があり、kind ごとに
+  /// **どちらか一方だけ**を使う:
+  ///
+  /// - **行ごと採番**（`equation` / `align` / `gather`）: 各行の `MathRow::number` に通し番号が入る。
+  ///   環境全体の `number` は `None`。
+  /// - **環境全体に 1 つ採番**（`split` / `multiline`）: この `number` フィールドに 1 つだけ通し番号が入り、
+  ///   `layout` 段がブロックの縦中央に配置する。各行の `MathRow::number` は `None`。
+  ///
+  /// いずれも番号は `CounterRegistry::increment(CounterName::Equation)` で発番された通し番号
+  /// （`format` テンプレ適用済みの文字列）で、lowering 層が `EquationStyle::number_format` でさらに
+  /// 装飾する。`[numbered=false]` で採番ありの環境を無採番にした場合は両方とも `None`。`kind` に応じて
+  /// lowering 以降が列整列・区切り括弧・中央寄せを決める。
   MathBlock {
     /// 環境種別
     kind: MathEnvKind,
     /// 行（各行は `&` 区切りの列を持つ）
     rows: Vec<MathRow>,
+    /// 環境全体に 1 つだけ付く通し番号（`split` / `multiline` 用、縦中央配置）。
+    /// 行ごと採番の環境（`equation` / `align` / `gather`）や無採番では `None`
+    number: Option<String>,
   },
 
   /// 図環境（`\begin{figure}...\end{figure}`）

--- a/crates/layout/src/lib.rs
+++ b/crates/layout/src/lib.rs
@@ -180,13 +180,15 @@ impl Measurer<'_> {
         LayoutNode::MathBlock {
           kind,
           rows,
+          env_number,
           align: block_align,
           numbers_on_right,
           row_gap,
           column_gap,
         } => {
           self.flush_paragraph(blocks, paragraph, indent, align);
-          let math_block = self.build_math_block(kind, rows, block_align, numbers_on_right, row_gap, column_gap);
+          let math_block =
+            self.build_math_block(kind, rows, env_number, block_align, numbers_on_right, row_gap, column_gap);
           blocks.push(math_block);
         },
         LayoutNode::PageBreak => {

--- a/crates/layout/src/math.rs
+++ b/crates/layout/src/math.rs
@@ -6,13 +6,13 @@
 //! 本文幅に依存する処理（本体の中央寄せ・番号の端寄せ）だけを `hlist::break_pages` に委ねる。
 
 use hlist::{Block, HBox, MathRowNumber, PlacedHItem};
-use lowering::MathBlockRow;
-use types::{Align, MathEnvKind};
+use lowering::{LayoutNode, MathBlockRow};
+use types::{Align, FontType, MathDelimiter, MathEnvKind};
 
 use crate::Measurer;
 
 /// セルの列内での水平揃え（環境種別ごとに決まる）
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CellAlign {
   /// 左揃え
   Left,
@@ -22,22 +22,34 @@ enum CellAlign {
   Right,
 }
 
-/// 環境種別と列インデックスから、その列のセルの水平揃えを決める
+/// 環境種別・行位置・列インデックスから、そのセルの列内での水平揃えを決める
 ///
-/// - `align`: 奇数列（0 始まりで偶数番目）を右、続く列を左に寄せて `&` 位置で接合する
+/// - `align` / `split`: 奇数列（0 始まりで偶数番目）を右、続く列を左に寄せて `&` 位置で接合する
+/// - `gather`: 全セル中央揃え（単一列なのでブロック内中央寄せになる）
+/// - `multiline`: 単一列で、先頭行=左・末尾行=右・中間行=中央の階段配置（1 行なら中央）
 /// - `matrix`: 全セル中央揃え
-/// - `equation` / `gather` / `cases`: 左揃え（`gather` の行中央寄せは将来対応）
-fn column_align(kind: MathEnvKind, col: usize) -> CellAlign {
+/// - `equation` / `cases`: 左揃え
+fn cell_align(kind: MathEnvKind, row_idx: usize, n_rows: usize, col: usize) -> CellAlign {
   return match kind {
-    MathEnvKind::Align => {
+    MathEnvKind::Align | MathEnvKind::Split => {
       if col.is_multiple_of(2) {
         CellAlign::Right
       } else {
         CellAlign::Left
       }
     },
-    MathEnvKind::Matrix { .. } => CellAlign::Center,
-    MathEnvKind::Equation | MathEnvKind::Gather | MathEnvKind::Cases => CellAlign::Left,
+    MathEnvKind::Multiline => {
+      if n_rows <= 1 || (row_idx > 0 && row_idx < n_rows - 1) {
+        CellAlign::Center
+      } else if row_idx == 0 {
+        CellAlign::Left
+      } else {
+        CellAlign::Right
+      }
+    },
+    // gather は単一列の中央寄せ、matrix はグリッド中央寄せ（いずれも結果は中央揃え）
+    MathEnvKind::Gather | MathEnvKind::Matrix { .. } => CellAlign::Center,
+    MathEnvKind::Equation | MathEnvKind::Cases => CellAlign::Left,
   };
 }
 
@@ -47,6 +59,25 @@ fn column_offset(align: CellAlign, col_width: f32, cell_width: f32) -> f32 {
     CellAlign::Left => 0.0,
     CellAlign::Center => (col_width - cell_width) / 2.0,
     CellAlign::Right => col_width - cell_width,
+  };
+}
+
+/// 環境種別から本体グリッドを囲む左右の区切り括弧グリフ `(左, 右)` を決める
+///
+/// `cases` は左の大波括弧のみ（右は無し）、`matrix` は `[delimiter=...]` の指定に応じた左右ペア
+/// （`none` は括弧なし）。区切り括弧を持たない環境（`equation` / `align` 等）は `(None, None)`。
+fn delimiter_glyphs(kind: MathEnvKind) -> (Option<&'static str>, Option<&'static str>) {
+  return match kind {
+    MathEnvKind::Cases => (Some("{"), None),
+    MathEnvKind::Matrix { delimiter } => match delimiter {
+      MathDelimiter::None => (None, None),
+      MathDelimiter::Paren => (Some("("), Some(")")),
+      MathDelimiter::Bracket => (Some("["), Some("]")),
+      MathDelimiter::Brace => (Some("{"), Some("}")),
+      MathDelimiter::Bar => (Some("|"), Some("|")),
+      MathDelimiter::DoubleBar => (Some("\u{2016}"), Some("\u{2016}")),
+    },
+    _ => (None, None),
   };
 }
 
@@ -62,12 +93,15 @@ impl Measurer<'_> {
   /// `LayoutNode::MathBlock` を measure して `Block::MathBlock` に合成する
   ///
   /// 各セルを `build_atom` で閉じた Atom にし、列ごとの最大幅で列位置を確定、行を縦に
-  /// 積んで 1 つの本体 Atom にまとめる。番号は行ごとに別ボックスとして保持し、最終的な
-  /// 端寄せは `break_pages` に委ねる。
+  /// 積んで 1 つの本体 Atom にまとめる。行ごと番号（`align` / `gather`）は各行のベースラインに、
+  /// 環境全体に 1 つの番号（`split` / `multiline` の `env_number`）はブロック縦中央に別ボックスとして
+  /// 保持し、最終的な端寄せ（`numbers_on_right`）は `break_pages` に委ねる。
+  #[allow(clippy::too_many_arguments)]
   pub(crate) fn build_math_block(
     &mut self,
     kind: MathEnvKind,
     rows: Vec<MathBlockRow>,
+    env_number: Option<Vec<LayoutNode>>,
     align: Align,
     numbers_on_right: bool,
     row_gap: f32,
@@ -84,6 +118,7 @@ impl Measurer<'_> {
       .collect();
 
     // 列幅 = その列のセルの最大幅。列位置 = 列幅 + 列間アキの累積
+    let n_rows = measured.len();
     let ncols = measured.iter().map(|row| row.cells.len()).max().unwrap_or(0);
     let mut col_widths = vec![0.0f32; ncols];
     for row in &measured {
@@ -110,7 +145,7 @@ impl Measurer<'_> {
         baseline_dy -= prev_depth + row_gap + row_height;
       }
       for (c, cell) in row.cells.into_iter().enumerate() {
-        let intra = column_offset(column_align(kind, c), col_widths[c], cell.width);
+        let intra = column_offset(cell_align(kind, i, n_rows, c), col_widths[c], cell.width);
         placed.push(PlacedHItem {
           item: cell,
           dy: baseline_dy,
@@ -126,11 +161,193 @@ impl Measurer<'_> {
       prev_depth = row_depth;
     }
 
+    let mut body = HBox::atom(placed);
+
+    // 環境全体に 1 つの番号（split / multiline）はブロック縦中央に配置する。
+    // body のベースライン（dy = 0）基準でブロック中央へ番号の視覚中央を合わせる
+    // （dy は正で上方向。`break_pages` が `baseline_y - dy` を番号ベースラインにする）。
+    if let Some(env_number) = env_number {
+      let number = self.build_atom(0.0, env_number);
+      let center_dy = (body.height - body.depth) / 2.0 - (number.height - number.depth) / 2.0;
+      numbers.push(MathRowNumber {
+        content: number,
+        dy: center_dy,
+      });
+    }
+
+    // 区切り括弧（cases / matrix）は本体 Atom を左右の括弧で挟んで包み直す。
+    // cases / matrix は無採番（`numbers` 空）なので本体の水平シフトは番号配置に影響しない。
+    let (left, right) = delimiter_glyphs(kind);
+    if left.is_some() || right.is_some() {
+      body = self.wrap_with_delimiters(body, left, right);
+    }
+
     return Block::MathBlock {
-      body: HBox::atom(placed),
+      body,
       numbers,
       numbers_on_right,
       align,
     };
+  }
+
+  /// 区切り括弧グリフを本体グリッドの高さ・深さに合わせて拡大した閉じたボックスにして返す
+  ///
+  /// `ch` を数式フォントで基準サイズにシェーピングして自然な高さ＋深さを得たのち、目標高さ
+  /// （`target_height + target_depth` に上下の余白を足した値）に対する倍率でフォントサイズを拡大して
+  /// 再シェーピングする。OpenType MATH 由来の伸縮グリフ組立ではなく、1 グリフの一様拡大で近似する
+  /// （read-fonts が MATH 未対応のため。本物の伸縮は将来対応 → #67 周辺）。
+  fn shape_delimiter(&mut self, ch: &str, target_height: f32, target_depth: f32) -> HBox {
+    let base = self.default_font_size;
+    let natural = self.shape_segment(ch, FontType::Math, base, None);
+    let natural_total = natural.height + natural.depth;
+    let pad = base * 0.1;
+    let target_total = target_height + target_depth + 2.0 * pad;
+    // 拡大のみ（自然サイズより小さくはしない）。小さなグリッドでも括弧は通常字より縮めない
+    let scale = if natural_total > 0.0 {
+      (target_total / natural_total).max(1.0)
+    } else {
+      1.0
+    };
+    return self.shape_segment(ch, FontType::Math, base * scale, None);
+  }
+
+  /// 本体 Atom を左右の区切り括弧で挟んで包み直す
+  ///
+  /// 各括弧は本体の縦中央（数式軸 `(height - depth) / 2`）にグリフの縦中央を合わせて配置し、左括弧→
+  /// 本体→右括弧を水平に並べて 1 つの Atom にまとめる。右が `None` の場合（`cases`）は左括弧のみ付く。
+  fn wrap_with_delimiters(&mut self, body: HBox, left: Option<&str>, right: Option<&str>) -> HBox {
+    let body_height = body.height;
+    let body_depth = body.depth;
+    let body_width = body.width;
+    let body_center = (body_height - body_depth) / 2.0;
+    let gap = self.default_font_size * 0.15;
+
+    let mut children: Vec<PlacedHItem> = Vec::new();
+    let mut dx = 0.0f32;
+    if let Some(ch) = left {
+      let delim = self.shape_delimiter(ch, body_height, body_depth);
+      let dy = body_center - (delim.height - delim.depth) / 2.0;
+      let width = delim.width;
+      children.push(PlacedHItem {
+        item: delim,
+        dy,
+        dx,
+      });
+      dx += width + gap;
+    }
+    children.push(PlacedHItem {
+      item: body,
+      dy: 0.0,
+      dx,
+    });
+    dx += body_width + gap;
+    if let Some(ch) = right {
+      let delim = self.shape_delimiter(ch, body_height, body_depth);
+      let dy = body_center - (delim.height - delim.depth) / 2.0;
+      children.push(PlacedHItem {
+        item: delim,
+        dy,
+        dx,
+      });
+    }
+    return HBox::atom(children);
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use types::{MathDelimiter, MathEnvKind};
+
+  use super::{CellAlign, cell_align, column_offset, delimiter_glyphs};
+
+  #[test]
+  fn cell_align_align_and_split_alternate_right_left_by_column() {
+    // Arrange & Act & Assert — align / split は偶数列(0始まり)=右・奇数列=左で `&` 位置に接合
+    for kind in [MathEnvKind::Align, MathEnvKind::Split] {
+      assert_eq!(cell_align(kind, 0, 1, 0), CellAlign::Right, "列 0 は右: {kind:?}");
+      assert_eq!(cell_align(kind, 0, 1, 1), CellAlign::Left, "列 1 は左: {kind:?}");
+      assert_eq!(cell_align(kind, 0, 1, 2), CellAlign::Right, "列 2 は右: {kind:?}");
+    }
+  }
+
+  #[test]
+  fn cell_align_gather_is_always_center() {
+    // Arrange & Act & Assert — gather は全行中央（単一列なのでブロック内中央寄せ）
+    assert_eq!(cell_align(MathEnvKind::Gather, 0, 3, 0), CellAlign::Center);
+    assert_eq!(cell_align(MathEnvKind::Gather, 1, 3, 0), CellAlign::Center);
+    assert_eq!(cell_align(MathEnvKind::Gather, 2, 3, 0), CellAlign::Center);
+  }
+
+  #[test]
+  fn cell_align_multiline_is_staircase() {
+    // Arrange & Act & Assert — multiline は先頭=左・末尾=右・中間=中央
+    let kind = MathEnvKind::Multiline;
+    assert_eq!(cell_align(kind, 0, 3, 0), CellAlign::Left, "先頭行は左");
+    assert_eq!(cell_align(kind, 1, 3, 0), CellAlign::Center, "中間行は中央");
+    assert_eq!(cell_align(kind, 2, 3, 0), CellAlign::Right, "末尾行は右");
+  }
+
+  #[test]
+  fn cell_align_multiline_single_row_is_center() {
+    // Arrange & Act & Assert — 1 行だけの multiline は中央
+    assert_eq!(cell_align(MathEnvKind::Multiline, 0, 1, 0), CellAlign::Center);
+  }
+
+  #[test]
+  fn cell_align_matrix_center_equation_and_cases_left() {
+    // Arrange & Act & Assert — matrix は中央、equation / cases は左
+    assert_eq!(
+      cell_align(
+        MathEnvKind::Matrix {
+          delimiter: MathDelimiter::None
+        },
+        0,
+        2,
+        0
+      ),
+      CellAlign::Center
+    );
+    assert_eq!(cell_align(MathEnvKind::Equation, 0, 1, 0), CellAlign::Left);
+    assert_eq!(cell_align(MathEnvKind::Cases, 0, 2, 0), CellAlign::Left);
+  }
+
+  #[test]
+  fn delimiter_glyphs_maps_cases_and_matrix() {
+    // Arrange & Act & Assert — cases は左波括弧のみ、matrix は delimiter 指定に応じた左右ペア
+    assert_eq!(delimiter_glyphs(MathEnvKind::Cases), (Some("{"), None));
+    assert_eq!(
+      delimiter_glyphs(MathEnvKind::Matrix {
+        delimiter: MathDelimiter::Bracket
+      }),
+      (Some("["), Some("]"))
+    );
+    assert_eq!(
+      delimiter_glyphs(MathEnvKind::Matrix {
+        delimiter: MathDelimiter::Paren
+      }),
+      (Some("("), Some(")"))
+    );
+  }
+
+  #[test]
+  fn delimiter_glyphs_absent_for_none_and_other_envs() {
+    // Arrange & Act & Assert — matrix の delimiter=none と、括弧を持たない環境は (None, None)
+    assert_eq!(
+      delimiter_glyphs(MathEnvKind::Matrix {
+        delimiter: MathDelimiter::None
+      }),
+      (None, None)
+    );
+    assert_eq!(delimiter_glyphs(MathEnvKind::Equation), (None, None));
+    assert_eq!(delimiter_glyphs(MathEnvKind::Align), (None, None));
+  }
+
+  #[test]
+  fn column_offset_places_cell_within_column_width() {
+    // Arrange — 列幅 10、セル幅 4
+    // Act & Assert — 左=0、中央=(10-4)/2=3、右=10-4=6
+    assert!((column_offset(CellAlign::Left, 10.0, 4.0) - 0.0).abs() < f32::EPSILON);
+    assert!((column_offset(CellAlign::Center, 10.0, 4.0) - 3.0).abs() < f32::EPSILON);
+    assert!((column_offset(CellAlign::Right, 10.0, 4.0) - 6.0).abs() < f32::EPSILON);
   }
 }

--- a/crates/lowering/src/layout_node.rs
+++ b/crates/lowering/src/layout_node.rs
@@ -84,7 +84,7 @@ pub enum LayoutNode {
   /// セルごとに `HItem` 列へ変換される。列幅の解決（自然幅の実測・残余分配）は
   /// `hlist` 段、罫線・行の描画は `pdf_gen` 段で行う。
   Table(TableLayout),
-  /// ディスプレイ数式環境（`equation` / `align` / `gather` / `cases` / `matrix`）
+  /// ディスプレイ数式環境（`equation` / `align` / `gather` / `split` / `multiline` / `cases` / `matrix`）
   ///
   /// 各セルはシェーピング前の lower 済みインライン数式（`Vec<LayoutNode>`）のまま保持し、
   /// `layout` 段が `kind` に応じてセルを閉じた Atom に measure・列整列・行積みして
@@ -93,8 +93,11 @@ pub enum LayoutNode {
   MathBlock {
     /// 環境種別（列整列・区切り括弧・採番の決定に使う）
     kind: MathEnvKind,
-    /// 行（各行は `&` 区切りの列と任意の番号を持つ）
+    /// 行（各行は `&` 区切りの列と任意の行番号を持つ）
     rows: Vec<MathBlockRow>,
+    /// 環境全体に 1 つだけ付く番号ボックス（`split` / `multiline` 用、lower 済み）。
+    /// `layout` 段がブロックの縦中央に配置する。行ごと採番や無採番では `None`
+    env_number: Option<Vec<LayoutNode>>,
     /// 本文幅の中での本体の水平揃え（既定は中央寄せ）
     align: Align,
     /// 番号を本文右端に寄せるか（`false` なら左端）

--- a/crates/lowering/src/lib.rs
+++ b/crates/lowering/src/lib.rs
@@ -203,13 +203,13 @@ fn lower_node_indexed(
       // ラベル付きブロックと同じ `AnchorMark::Label` でジャンプ先に解決させる。
       return Ok(vec![LayoutNode::Anchor(types::AnchorMark::Label(target.clone()))]);
     },
-    DocNode::MathBlock { kind, rows } => {
+    DocNode::MathBlock { kind, rows, number } => {
       let eq = &ctx.style.equation;
       let mut nodes = vec![
         LayoutNode::Vkern {
           length: eq.top_margin,
         },
-        math::lower_math_block(ctx, *kind, rows),
+        math::lower_math_block(ctx, *kind, rows, number.as_deref()),
         LayoutNode::Vkern {
           length: eq.bottom_margin,
         },
@@ -290,6 +290,7 @@ mod tests {
         number: number.map(str::to_string),
         label: label.map(str::to_string),
       }],
+      number: None,
     };
   }
 

--- a/crates/lowering/src/math.rs
+++ b/crates/lowering/src/math.rs
@@ -20,16 +20,22 @@ fn script_font_size(font_size: f32, math_style: &MathStyleConfig) -> f32 {
   return (font_size * math_style.script_size_factor).max(math_style.min_script_font_size.to_pt());
 }
 
-/// `DocNode::MathBlock`（`equation` / `align` / `gather` / `cases` / `matrix`）を
+/// `DocNode::MathBlock`（`equation` / `align` / `gather` / `split` / `multiline` / `cases` / `matrix`）を
 /// `LayoutNode::MathBlock` に変換する
 ///
-/// 各行の各セル（`&` 区切りの列）を [`lower_inline_math`] で lower し、採番された行は
+/// 各行の各セル（`&` 区切りの列）を [`lower_inline_math`] で lower し、採番された行・環境は
 /// `EquationStyle::number_format` の `{number}` を発番番号で置換した文字列を `FontKind::Serif`
-/// （数字は立体）の番号ボックスに包む。列整列・行積み・区切り括弧の配置は `layout` 段が
+/// （数字は立体）の番号ボックスに包む。`env_number_str` は `split` / `multiline` の環境全体に 1 つの
+/// 番号で、`layout` 段がブロック縦中央に配置する。列整列・行積み・区切り括弧の配置は `layout` 段が
 /// `kind` に応じて確定し、本体の中央寄せ（`align`）と番号の端寄せ（`numbers_on_right`）は
 /// `break_pages` 段が本文幅を使って決める。上下マージンは呼び出し側（[`crate`] のディスパッチ）が
 /// `Vkern` で前後に出す。
-pub(super) fn lower_math_block(ctx: &LoweringContext, kind: MathEnvKind, rows: &[MathRow]) -> LayoutNode {
+pub(super) fn lower_math_block(
+  ctx: &LoweringContext,
+  kind: MathEnvKind,
+  rows: &[MathRow],
+  env_number_str: Option<&str>,
+) -> LayoutNode {
   let font_size = ctx.default_font_size();
   let eq = &ctx.style.equation;
   let mb = &ctx.style.math_block;
@@ -38,29 +44,38 @@ pub(super) fn lower_math_block(ctx: &LoweringContext, kind: MathEnvKind, rows: &
     .iter()
     .map(|row| {
       let cells = row.cells.iter().map(|cell| lower_inline_math(cell, font_size, &ctx.style.math)).collect();
-      let number = row.number.as_deref().map(|n| {
-        let text = eq.number_format.replace("{number}", n);
-        return vec![LayoutNode::Text(
-          text,
-          TextStyle {
-            font_size,
-            font_kind: FontKind::Serif,
-            color: None,
-          },
-        )];
-      });
+      let number = row.number.as_deref().map(|n| number_box(&eq.number_format, n, font_size));
       return MathBlockRow { cells, number };
     })
     .collect();
 
+  let env_number = env_number_str.map(|n| number_box(&eq.number_format, n, font_size));
+
   return LayoutNode::MathBlock {
     kind,
     rows: layout_rows,
+    env_number,
     align: alignment_to_align(eq.alignment),
     numbers_on_right: matches!(eq.number_side, NumberSide::Right),
     row_gap: mb.row_gap.to_pt(),
     column_gap: mb.column_gap.to_pt(),
   };
+}
+
+/// 発番された通し番号を番号書式テンプレートに当てはめ、立体（Serif）の番号ボックスを作る
+///
+/// `number_format` の `{number}` を `n` で置換し（既定 `"({number})"` → `"(1)"`）、数字を
+/// `FontKind::Serif` で描く `LayoutNode::Text` 1 つにまとめる。行ごと番号と環境全体番号の双方で使う。
+fn number_box(number_format: &str, n: &str, font_size: f32) -> Vec<LayoutNode> {
+  let text = number_format.replace("{number}", n);
+  return vec![LayoutNode::Text(
+    text,
+    TextStyle {
+      font_size,
+      font_kind: FontKind::Serif,
+      color: None,
+    },
+  )];
 }
 
 /// `read_style::Alignment`（数式本体の揃え）を `types::Align` に対応付ける
@@ -387,7 +402,7 @@ mod tests {
     let rows = vec![numbered_row("2")];
 
     // Act
-    let node = lower_math_block(&ctx, MathEnvKind::Equation, &rows);
+    let node = lower_math_block(&ctx, MathEnvKind::Equation, &rows, None);
 
     // Assert: その行の number ボックスが "(2)" の Serif Text 1 個
     let LayoutNode::MathBlock {
@@ -411,7 +426,7 @@ mod tests {
     let rows = vec![numbered_row("3")];
 
     // Act
-    let node = lower_math_block(&ctx, MathEnvKind::Equation, &rows);
+    let node = lower_math_block(&ctx, MathEnvKind::Equation, &rows, None);
 
     // Assert
     let LayoutNode::MathBlock {
@@ -435,7 +450,7 @@ mod tests {
     let rows = vec![numbered_row("3")];
 
     // Act
-    let node = lower_math_block(&ctx, MathEnvKind::Equation, &rows);
+    let node = lower_math_block(&ctx, MathEnvKind::Equation, &rows, None);
 
     // Assert
     let LayoutNode::MathBlock {

--- a/crates/lowering/tests/smoke.rs
+++ b/crates/lowering/tests/smoke.rs
@@ -43,6 +43,24 @@ fn smoke_figure_fixture() { smoke_through_lowering("figure"); }
 fn smoke_equation_fixture() { smoke_through_lowering("equation"); }
 
 #[test]
+fn smoke_align_fixture() { smoke_through_lowering("align"); }
+
+#[test]
+fn smoke_gather_fixture() { smoke_through_lowering("gather"); }
+
+#[test]
+fn smoke_split_fixture() { smoke_through_lowering("split"); }
+
+#[test]
+fn smoke_multiline_fixture() { smoke_through_lowering("multiline"); }
+
+#[test]
+fn smoke_cases_fixture() { smoke_through_lowering("cases"); }
+
+#[test]
+fn smoke_matrix_fixture() { smoke_through_lowering("matrix"); }
+
+#[test]
 fn smoke_ref_fixture() { smoke_through_lowering("ref"); }
 
 #[test]

--- a/crates/parser/src/evaluator/environment.rs
+++ b/crates/parser/src/evaluator/environment.rs
@@ -23,12 +23,18 @@ use syntax::{ParseMode, ast::EnvironmentView};
 
 use crate::evaluator::{EvalError, Evaluator};
 
+mod align;
 pub(crate) mod body_scan;
 mod caption;
+mod cases;
 mod equation;
 mod figure;
+mod gather;
 mod itemize;
 mod math_grid;
+mod matrix;
+mod multiline;
+mod split;
 mod table;
 
 /// 環境ハンドラの関数ポインタ型
@@ -55,9 +61,15 @@ pub(crate) struct EnvDef {
 pub(crate) static ENVIRONMENTS: phf::Map<&'static str, EnvDef> = phf_map! {
   "itemize"   => EnvDef { parse_mode: ParseMode::Text, handler: Some(itemize::itemize),   display_name: "箇条書きリスト" },
   "enumerate" => EnvDef { parse_mode: ParseMode::Text, handler: Some(itemize::enumerate), display_name: "番号付きリスト" },
-  "equation"  => EnvDef { parse_mode: ParseMode::Math, handler: Some(equation::equation), display_name: "数式" },
-  "figure"    => EnvDef { parse_mode: ParseMode::Text, handler: Some(figure::figure),     display_name: "図" },
-  "table"     => EnvDef { parse_mode: ParseMode::Text, handler: Some(table::table),       display_name: "表" },
+  "equation"  => EnvDef { parse_mode: ParseMode::Math, handler: Some(equation::equation),   display_name: "数式" },
+  "align"     => EnvDef { parse_mode: ParseMode::Math, handler: Some(align::align),         display_name: "整列数式" },
+  "gather"    => EnvDef { parse_mode: ParseMode::Math, handler: Some(gather::gather),       display_name: "中央寄せ数式" },
+  "split"     => EnvDef { parse_mode: ParseMode::Math, handler: Some(split::split),         display_name: "分割数式" },
+  "multiline" => EnvDef { parse_mode: ParseMode::Math, handler: Some(multiline::multiline), display_name: "多行数式" },
+  "cases"     => EnvDef { parse_mode: ParseMode::Math, handler: Some(cases::cases),         display_name: "場合分け" },
+  "matrix"    => EnvDef { parse_mode: ParseMode::Math, handler: Some(matrix::matrix),       display_name: "行列" },
+  "figure"    => EnvDef { parse_mode: ParseMode::Text, handler: Some(figure::figure),       display_name: "図" },
+  "table"     => EnvDef { parse_mode: ParseMode::Text, handler: Some(table::table),         display_name: "表" },
 };
 
 /// 環境名から構文解析モードを引く

--- a/crates/parser/src/evaluator/environment/align.rs
+++ b/crates/parser/src/evaluator/environment/align.rs
@@ -1,0 +1,206 @@
+//! 数式環境 — `align`
+//!
+//! `\begin{align}...\end{align}` を [`DocNode::MathBlock`]（`kind = Align`）に変換します。本体は
+//! [`syntax::ParseMode::Math`] で構造化された CST を行区切り `\\` × 列区切り `&` のグリッドに分割し、
+//! 各行を [`read_style::CounterName::Equation`] で採番します。実体は共通ハンドラ
+//! [`super::math_grid::evaluate_math_env`]（`NumberingMode::PerRow`）に委譲します。列整列（奇数列＝右・
+//! 偶数列＝左で `&` 位置に接合）は `layout` 段が [`MathEnvKind::Align`] に応じて確定します。
+//!
+//! ## 任意引数
+//!
+//! - `[numbered=false]` — 環境全体を無採番にする（行単位のラベル・無採番指定は将来対応 → 親 issue #25）
+
+use document::{DocNode, MathEnvKind};
+use syntax::ast::EnvironmentView;
+
+use super::math_grid::{GridSpec, NumberingMode, evaluate_math_env};
+use crate::evaluator::{EvalError, Evaluator};
+
+/// `align` 環境を評価する
+///
+/// 本体を `\\` で行・`&` で列に分割し、各行に [`read_style::CounterName::Equation`] の通し番号を
+/// 発番した `MathRow` 列を持つ `MathBlock`（`kind = Align`）を返す。`[numbered=false]` 指定時は採番しない。
+///
+/// # Errors
+///
+/// 未知の任意引数キー・位置引数の指定、本体のセル評価失敗時にエラーを返します
+pub(super) fn align(view: &EnvironmentView, evaluator: &mut Evaluator) -> Result<Vec<DocNode>, EvalError> {
+  return evaluate_math_env(
+    view,
+    evaluator,
+    MathEnvKind::Align,
+    &GridSpec {
+      allow_row_breaks: true,
+      allow_column_breaks: true,
+    },
+    &NumberingMode::PerRow,
+  );
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+  use bumpalo::Bump;
+  use document::{MathEnvKind, MathNode};
+  use read_style::{Counters, Style};
+
+  use super::*;
+  use crate::evaluator::lookup_env_parse_mode;
+
+  /// テスト用 `parse` ラッパ — `env_mode` に本番レジストリを自動注入する
+  fn parse<'a>(source: &'a str, arena: &'a Bump) -> Result<&'a syntax::green::GreenNode<'a>, syntax::ParserError> {
+    return syntax::parse(source, arena, lookup_env_parse_mode);
+  }
+
+  /// equation カウンタの `format` を `"{n}"` に差し替えた Style を返す
+  ///
+  /// 既定の `"{chapter}.{n}"` は通し番号の確認には本質的でないため、番号を素朴な `"1"`, `"2"`
+  /// 形式に縮約してテストの意図を読みやすくする。
+  fn style_with_plain_equation_format() -> Style {
+    let mut counters = Counters::default();
+    counters.equation.format = "{n}".to_string();
+    return Style {
+      counters,
+      ..Default::default()
+    };
+  }
+
+  /// 結果の最初の `DocNode::MathBlock`（`Align`）の行スライスを取り出すヘルパ
+  fn rows_of(result: &[DocNode]) -> &[document::MathRow] {
+    let DocNode::MathBlock { kind, rows, .. } = &result[0] else {
+      panic!("MathBlock が期待されます: {:?}", result[0]);
+    };
+    assert_eq!(*kind, MathEnvKind::Align, "align は MathEnvKind::Align");
+    return rows;
+  }
+
+  #[test]
+  fn align_splits_rows_and_columns_and_numbers_each_row() {
+    // Arrange — 2 行 × 2 列の align（`&` で整列、`\\` で行分割）
+    let arena = Bump::new();
+    let source = r"\begin{align}a &= b \\ c &= d\end{align}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::new(&style_with_plain_equation_format());
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst).unwrap();
+
+    // Assert — MathBlock(Align) 1 件、2 行・各 2 セル、各行が通し番号を持つ
+    assert_eq!(result.len(), 1);
+    let rows = rows_of(&result);
+    assert_eq!(rows.len(), 2, "2 行に分割される: {rows:?}");
+    assert_eq!(rows[0].cells.len(), 2, "行 0 は 2 列");
+    assert_eq!(rows[1].cells.len(), 2, "行 1 は 2 列");
+    assert_eq!(rows[0].number.as_deref(), Some("1"));
+    assert_eq!(rows[1].number.as_deref(), Some("2"));
+  }
+
+  #[test]
+  fn align_single_row_is_numbered() {
+    // Arrange — 行・列分割のない 1 行の align も採番される
+    let arena = Bump::new();
+    let source = r"\begin{align}x &= y\end{align}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::new(&style_with_plain_equation_format());
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst).unwrap();
+
+    // Assert
+    let rows = rows_of(&result);
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].cells.len(), 2);
+    assert_eq!(rows[0].number.as_deref(), Some("1"));
+  }
+
+  #[test]
+  fn align_drops_trailing_blank_row_from_trailing_break() {
+    // Arrange — 行末 `\\`（その後ろは空白のみ）は空行を生むが採番せず捨てる
+    let arena = Bump::new();
+    let source = "\\begin{align}a &= b \\\\\n\\end{align}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::new(&style_with_plain_equation_format());
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst).unwrap();
+
+    // Assert — 末尾の空行は除去され、採番は 1 行ぶんだけ
+    let rows = rows_of(&result);
+    assert_eq!(rows.len(), 1, "末尾の空行が除去される: {rows:?}");
+    assert_eq!(rows[0].number.as_deref(), Some("1"));
+  }
+
+  #[test]
+  fn align_numbers_share_equation_counter_with_equation() {
+    // Arrange — align の各行と後続 equation が同じ equation カウンタを共有して連番になる
+    let arena = Bump::new();
+    let source = r"\begin{align}a &= b \\ c &= d\end{align}\begin{equation}e\end{equation}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::new(&style_with_plain_equation_format());
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst).unwrap();
+
+    // Assert — align の 2 行が 1, 2、続く equation が 3
+    assert_eq!(result.len(), 2);
+    let align_rows = rows_of(&result[..1]);
+    assert_eq!(align_rows[0].number.as_deref(), Some("1"));
+    assert_eq!(align_rows[1].number.as_deref(), Some("2"));
+    let DocNode::MathBlock { rows: eq_rows, .. } = &result[1] else {
+      panic!("equation の MathBlock が期待されます: {:?}", result[1]);
+    };
+    assert_eq!(eq_rows[0].number.as_deref(), Some("3"));
+  }
+
+  #[test]
+  fn align_numbered_false_suppresses_numbering() {
+    // Arrange — `[numbered=false]` で各行が無採番になる
+    let arena = Bump::new();
+    let source = r"\begin{align}[numbered=false]a &= b \\ c &= d\end{align}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::new(&style_with_plain_equation_format());
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst).unwrap();
+
+    // Assert — 2 行とも number は None
+    let rows = rows_of(&result);
+    assert_eq!(rows.len(), 2);
+    assert!(rows.iter().all(|r| r.number.is_none()), "無採番のはず: {rows:?}");
+  }
+
+  #[test]
+  fn align_cell_content_is_evaluated() {
+    // Arrange — セル内の上付きが評価されて MathNode として現れる
+    let arena = Bump::new();
+    let source = r"\begin{align}x^2 &= y\end{align}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::new(&style_with_plain_equation_format());
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst).unwrap();
+
+    // Assert — 左セルに Superscript が含まれる
+    let rows = rows_of(&result);
+    assert!(
+      rows[0].cells[0].iter().any(|n| matches!(n, MathNode::Superscript(_))),
+      "左セルに Superscript ノードが含まれるべき: {:?}",
+      rows[0].cells[0]
+    );
+  }
+
+  #[test]
+  fn align_rejects_unknown_opt_args() {
+    // Arrange — align は `[numbered]` のみ許可。`[label=...]` は未知キーエラー
+    let arena = Bump::new();
+    let source = r"\begin{align}[label=eq:foo]a &= b\end{align}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::default();
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst);
+
+    // Assert
+    assert!(matches!(result, Err(EvalError::UnknownOptArgKey { ref key, .. }) if key == "label"));
+  }
+}

--- a/crates/parser/src/evaluator/environment/cases.rs
+++ b/crates/parser/src/evaluator/environment/cases.rs
@@ -1,0 +1,163 @@
+//! 数式環境 — `cases`
+//!
+//! `\begin{cases}...\end{cases}` を [`DocNode::MathBlock`]（`kind = Cases`）に変換します。本体は
+//! [`syntax::ParseMode::Math`] で構造化された CST を行区切り `\\` × 列区切り `&` のグリッドに分割し、
+//! 各行を「式 & 条件」の 2 列固定として扱います（3 列以上は [`EvalError::CasesColumnOverflow`]）。
+//! 左の大波括弧と 2 列の左揃えは `layout` 段が [`MathEnvKind::Cases`] に応じて確定します。
+//!
+//! `cases` は**非採番**であり、[`read_style::CounterName::Equation`] を一切消費しません（採番ありの
+//! 数式環境と通し番号を共有しない）。任意引数も位置引数も受け付けません。
+
+use document::{DocNode, MathEnvKind};
+use syntax::ast::EnvironmentView;
+
+use super::math_grid::{GridSpec, evaluate_grid, into_unnumbered_rows};
+use crate::evaluator::{EvalError, Evaluator, opt_args::collect_environment_opt_args};
+
+/// `cases` 環境を評価する
+///
+/// 本体を `\\` で行・`&` で列に分割し、各行を非採番の `MathRow` にした `MathBlock`（`kind = Cases`）を
+/// 返す。各行は最大 2 列まで（`式 & 条件`）。番号は付かない。
+///
+/// # Errors
+///
+/// 任意引数・位置引数の指定、本体のセル評価失敗、3 列以上の行が現れた場合にエラーを返します
+pub(super) fn cases(view: &EnvironmentView, _evaluator: &mut Evaluator) -> Result<Vec<DocNode>, EvalError> {
+  // cases は任意引数を受け付けない（未知キーはエラー）
+  collect_environment_opt_args(view, &[])?;
+  if !view.args().is_empty() {
+    return Err(EvalError::ExtraEnvironmentArgument {
+      name: "cases".to_string(),
+      span: view.span().into(),
+    });
+  }
+
+  let source = view.source();
+  let grid = match view.body() {
+    Some(body_node) => evaluate_grid(
+      source,
+      body_node,
+      &GridSpec {
+        allow_row_breaks: true,
+        allow_column_breaks: true,
+      },
+    )?,
+    None => Vec::new(),
+  };
+  let rows = into_unnumbered_rows(grid);
+  // cases は「式 & 条件」の 2 列固定。3 列以上はエラーにする
+  if let Some(row) = rows.iter().find(|row| row.cells.len() > 2) {
+    return Err(EvalError::CasesColumnOverflow {
+      found: row.cells.len(),
+      span: view.span().into(),
+    });
+  }
+
+  return Ok(vec![DocNode::MathBlock {
+    kind: MathEnvKind::Cases,
+    rows,
+    number: None,
+  }]);
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+  use bumpalo::Bump;
+  use document::MathEnvKind;
+  use read_style::{Counters, Style};
+
+  use super::*;
+  use crate::evaluator::lookup_env_parse_mode;
+
+  fn parse<'a>(source: &'a str, arena: &'a Bump) -> Result<&'a syntax::green::GreenNode<'a>, syntax::ParserError> {
+    return syntax::parse(source, arena, lookup_env_parse_mode);
+  }
+
+  /// equation カウンタの `format` を `"{n}"` に縮約した Style
+  fn style_with_plain_equation_format() -> Style {
+    let mut counters = Counters::default();
+    counters.equation.format = "{n}".to_string();
+    return Style {
+      counters,
+      ..Default::default()
+    };
+  }
+
+  fn rows_of(result: &[DocNode]) -> &[document::MathRow] {
+    let DocNode::MathBlock { kind, rows, number } = &result[0] else {
+      panic!("MathBlock が期待されます: {:?}", result[0]);
+    };
+    assert_eq!(*kind, MathEnvKind::Cases, "cases は MathEnvKind::Cases");
+    assert!(number.is_none(), "cases は非採番（環境番号なし）: {number:?}");
+    return rows;
+  }
+
+  #[test]
+  fn cases_splits_rows_and_two_columns_unnumbered() {
+    // Arrange — 2 行・各 2 列（式 & 条件）の cases
+    let arena = Bump::new();
+    let source = r"\begin{cases}a & x > 0 \\ b & x < 0\end{cases}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::new(&style_with_plain_equation_format());
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst).unwrap();
+
+    // Assert — 2 行・各 2 セル・全行 number は None
+    assert_eq!(result.len(), 1);
+    let rows = rows_of(&result);
+    assert_eq!(rows.len(), 2, "2 行に分割される: {rows:?}");
+    assert!(rows.iter().all(|r| r.cells.len() == 2), "各行 2 列: {rows:?}");
+    assert!(rows.iter().all(|r| r.number.is_none()), "非採番のはず: {rows:?}");
+  }
+
+  #[test]
+  fn cases_rejects_three_columns() {
+    // Arrange — 1 行 3 列はエラー（cases は 2 列固定）
+    let arena = Bump::new();
+    let source = r"\begin{cases}a & b & c\end{cases}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::default();
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst);
+
+    // Assert
+    assert!(matches!(result, Err(EvalError::CasesColumnOverflow { found: 3, .. })));
+  }
+
+  #[test]
+  fn cases_does_not_consume_equation_counter() {
+    // Arrange — cases は非採番。後続 equation は 1 から始まる（cases がカウンタを進めない）
+    let arena = Bump::new();
+    let source = r"\begin{cases}a & b\end{cases}\begin{equation}e\end{equation}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::new(&style_with_plain_equation_format());
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst).unwrap();
+
+    // Assert — equation の番号は 1（cases がカウンタを消費していない）
+    assert_eq!(result.len(), 2);
+    let DocNode::MathBlock { rows: eq_rows, .. } = &result[1] else {
+      panic!("equation の MathBlock が期待されます: {:?}", result[1]);
+    };
+    assert_eq!(eq_rows[0].number.as_deref(), Some("1"));
+  }
+
+  #[test]
+  fn cases_rejects_unknown_opt_key() {
+    // Arrange — cases は任意引数を受け付けない
+    let arena = Bump::new();
+    let source = r"\begin{cases}[foo=1]a & b\end{cases}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::default();
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst);
+
+    // Assert
+    assert!(matches!(result, Err(EvalError::UnknownOptArgKey { ref key, .. }) if key == "foo"));
+  }
+}

--- a/crates/parser/src/evaluator/environment/equation.rs
+++ b/crates/parser/src/evaluator/environment/equation.rs
@@ -66,6 +66,8 @@ pub(super) fn equation(view: &EnvironmentView, evaluator: &mut Evaluator) -> Res
   return Ok(vec![DocNode::MathBlock {
     kind: MathEnvKind::Equation,
     rows: vec![row],
+    // equation は行ごと採番（`row.number`）。環境全体の番号は使わない
+    number: None,
   }]);
 }
 
@@ -100,7 +102,7 @@ mod tests {
 
   /// 結果の最初の `DocNode::MathBlock` から唯一の行を取り出すヘルパ
   fn first_row(result: &[DocNode]) -> &document::MathRow {
-    let DocNode::MathBlock { kind, rows } = &result[0] else {
+    let DocNode::MathBlock { kind, rows, .. } = &result[0] else {
       panic!("MathBlock が期待されます: {:?}", result[0]);
     };
     assert_eq!(*kind, MathEnvKind::Equation, "equation は MathEnvKind::Equation");

--- a/crates/parser/src/evaluator/environment/gather.rs
+++ b/crates/parser/src/evaluator/environment/gather.rs
@@ -1,0 +1,120 @@
+//! 数式環境 — `gather`
+//!
+//! `\begin{gather}...\end{gather}` を [`DocNode::MathBlock`]（`kind = Gather`）に変換します。各行は
+//! `\\` で分割した単一セル（列区切り `&` は不可）で、各行を [`read_style::CounterName::Equation`] で
+//! 採番します。実体は共通ハンドラ [`super::math_grid::evaluate_math_env`]（`NumberingMode::PerRow`）に
+//! 委譲します。各行の中央寄せは `layout` 段が [`MathEnvKind::Gather`] に応じて確定します。
+//!
+//! ## 任意引数
+//!
+//! - `[numbered=false]` — 環境全体を無採番にする
+
+use document::{DocNode, MathEnvKind};
+use syntax::ast::EnvironmentView;
+
+use super::math_grid::{GridSpec, NumberingMode, evaluate_math_env};
+use crate::evaluator::{EvalError, Evaluator};
+
+/// `gather` 環境を評価する
+///
+/// 本体を `\\` で行に分割（`&` は不可）し、各行に通し番号を発番した `MathBlock`（`kind = Gather`）を
+/// 返す。`[numbered=false]` 指定時は採番しない。
+///
+/// # Errors
+///
+/// 未知の任意引数キー・位置引数の指定、本体への `&`（列区切り）混入、セル評価失敗時にエラーを返します
+pub(super) fn gather(view: &EnvironmentView, evaluator: &mut Evaluator) -> Result<Vec<DocNode>, EvalError> {
+  return evaluate_math_env(
+    view,
+    evaluator,
+    MathEnvKind::Gather,
+    &GridSpec {
+      allow_row_breaks: true,
+      allow_column_breaks: false,
+    },
+    &NumberingMode::PerRow,
+  );
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+  use bumpalo::Bump;
+  use document::MathEnvKind;
+  use read_style::{Counters, Style};
+
+  use super::*;
+  use crate::evaluator::lookup_env_parse_mode;
+
+  fn parse<'a>(source: &'a str, arena: &'a Bump) -> Result<&'a syntax::green::GreenNode<'a>, syntax::ParserError> {
+    return syntax::parse(source, arena, lookup_env_parse_mode);
+  }
+
+  /// equation カウンタの `format` を `"{n}"` に縮約した Style
+  fn style_with_plain_equation_format() -> Style {
+    let mut counters = Counters::default();
+    counters.equation.format = "{n}".to_string();
+    return Style {
+      counters,
+      ..Default::default()
+    };
+  }
+
+  fn rows_of(result: &[DocNode]) -> &[document::MathRow] {
+    let DocNode::MathBlock { kind, rows, .. } = &result[0] else {
+      panic!("MathBlock が期待されます: {:?}", result[0]);
+    };
+    assert_eq!(*kind, MathEnvKind::Gather, "gather は MathEnvKind::Gather");
+    return rows;
+  }
+
+  #[test]
+  fn gather_splits_rows_each_single_cell_and_numbers_each_row() {
+    // Arrange — 2 行・各 1 セルの gather
+    let arena = Bump::new();
+    let source = r"\begin{gather}a = b \\ c = d\end{gather}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::new(&style_with_plain_equation_format());
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst).unwrap();
+
+    // Assert — 2 行・各 1 セル・各行採番
+    let rows = rows_of(&result);
+    assert_eq!(rows.len(), 2, "2 行に分割される: {rows:?}");
+    assert!(rows.iter().all(|r| r.cells.len() == 1), "各行 1 セル: {rows:?}");
+    assert_eq!(rows[0].number.as_deref(), Some("1"));
+    assert_eq!(rows[1].number.as_deref(), Some("2"));
+  }
+
+  #[test]
+  fn gather_rejects_column_break() {
+    // Arrange — gather は `&`（列区切り）を許さない
+    let arena = Bump::new();
+    let source = r"\begin{gather}a & b\end{gather}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::default();
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst);
+
+    // Assert
+    assert!(matches!(result, Err(EvalError::UnsupportedInMath { .. })));
+  }
+
+  #[test]
+  fn gather_numbered_false_suppresses_numbering() {
+    // Arrange — `[numbered=false]` で無採番
+    let arena = Bump::new();
+    let source = r"\begin{gather}[numbered=false]a = b \\ c = d\end{gather}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::new(&style_with_plain_equation_format());
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst).unwrap();
+
+    // Assert
+    let rows = rows_of(&result);
+    assert!(rows.iter().all(|r| r.number.is_none()), "無採番のはず: {rows:?}");
+  }
+}

--- a/crates/parser/src/evaluator/environment/math_grid.rs
+++ b/crates/parser/src/evaluator/environment/math_grid.rs
@@ -1,4 +1,4 @@
-//! 複数行数式環境の構造分割器
+//! 複数行数式環境の構造分割器と共通ハンドラ
 //!
 //! 数式環境の本体（`EnvironmentBody`）をトップレベルの行区切り `\\`（[`TokenKind::LineBreak`]）で
 //! 行に、各行をトップレベルの列区切り `&`（[`TokenKind::Ampersand`]）でセルに分割し、各セルを
@@ -7,19 +7,28 @@
 //! 表環境の `\row` のセル分割（`environment/table.rs` の `extract_row`）と同じ「トップレベルの
 //! 区切りトークンで要素列を割る」方式を数式モードへ流用したもの。`equation` のように行・列分割を
 //! 許さない環境では、分割トークンの出現を [`EvalError::UnsupportedInMath`] にする。
+//!
+//! また、`align` / `gather` / `split` / `multiline` の各ハンドラが共有する評価本体 [`evaluate_math_env`]
+//! もここに置く（任意引数 `[numbered]` の解釈・グリッド分割・末尾空行除去・採番までを一手に行う）。
 
-use document::MathNode;
+use document::{DocNode, MathEnvKind, MathNode, MathRow};
+use read_style::CounterName;
 use syntax::{
+  ast::EnvironmentView,
   green::{GreenElement, GreenNode},
   token::TokenKind,
 };
 
-use crate::evaluator::{EvalError, math::evaluate_math_elements};
+use crate::evaluator::{
+  EvalError, Evaluator,
+  math::evaluate_math_elements,
+  opt_args::{OptType, collect_environment_opt_args, find_bool},
+};
 
 /// グリッド分割の許可設定（環境種別ごと）
 ///
-/// `equation` は両方 `false`（単一行・単一セル）、`gather` は行のみ、`align` / `matrix` / `cases`
-/// は両方 `true`。
+/// `equation` は両方 `false`（単一行・単一セル）、`gather` / `multiline` は行のみ、
+/// `align` / `split` / `matrix` / `cases` は両方 `true`。
 pub(crate) struct GridSpec {
   /// 行区切り `\\` を許可するか
   pub allow_row_breaks: bool,
@@ -81,6 +90,119 @@ pub(crate) fn evaluate_grid(
   current_row.push(evaluate_math_elements(source, &current_cell)?);
   rows.push(current_row);
   return Ok(rows);
+}
+
+/// 採番の粒度
+///
+/// 複数行数式環境が `CounterName::Equation` をどの単位で消費するかを表す。
+pub(crate) enum NumberingMode {
+  /// 各行に 1 つ採番する（`align` / `gather`）。番号は `MathRow::number` に入る
+  PerRow,
+  /// 環境全体に 1 つだけ採番する（`split` / `multiline`）。番号は `DocNode::MathBlock::number` に入り
+  /// `layout` 段が縦中央へ配置する
+  SingleEnv,
+}
+
+/// `align` / `gather` / `split` / `multiline` の共通評価本体
+///
+/// 任意引数 `[numbered]`（既定 `true`）のみを許可し、本体を `spec` に従って `\\`×`&` のグリッドへ
+/// 分割（[`evaluate_grid`]）したのち末尾の空行を除去し、`mode` に応じて採番した `DocNode::MathBlock`
+/// を返す。`numbered == false` のときは採番を一切行わない（採番ありの環境を無採番にする）。
+///
+/// # Errors
+///
+/// 未知の任意引数キー（`numbered` 以外）・位置引数の指定、本体のセル評価や許可しない区切りトークンの
+/// 出現時にエラーを返す。
+pub(crate) fn evaluate_math_env(
+  view: &EnvironmentView,
+  evaluator: &mut Evaluator,
+  kind: MathEnvKind,
+  spec: &GridSpec,
+  mode: &NumberingMode,
+) -> Result<Vec<DocNode>, EvalError> {
+  // 許可する任意引数は [numbered] のみ。既定は採番あり
+  let opt_args = collect_environment_opt_args(view, &[("numbered", OptType::Bool)])?;
+  let numbered = find_bool(opt_args, "numbered").unwrap_or(true);
+  if !view.args().is_empty() {
+    return Err(EvalError::ExtraEnvironmentArgument {
+      name: view.name().to_string(),
+      span: view.span().into(),
+    });
+  }
+
+  let source = view.source();
+  let mut grid = match view.body() {
+    Some(body_node) => evaluate_grid(source, body_node, spec)?,
+    None => Vec::new(),
+  };
+  // 行末の `\\` は分割器が末尾に空白だけの行を 1 つ生むため、採番前に除去する
+  while grid.last().is_some_and(|row| is_blank_row(row)) {
+    grid.pop();
+  }
+
+  let mut env_number = None;
+  let rows: Vec<MathRow> = match mode {
+    NumberingMode::PerRow => grid
+      .into_iter()
+      .map(|cells| {
+        let number = numbered.then(|| evaluator.registry.increment(CounterName::Equation));
+        return MathRow {
+          cells,
+          number,
+          label: None,
+        };
+      })
+      .collect(),
+    NumberingMode::SingleEnv => {
+      // 行は無採番。環境全体に 1 つだけ（空ブロックには採番しない）
+      if numbered && !grid.is_empty() {
+        env_number = Some(evaluator.registry.increment(CounterName::Equation));
+      }
+      grid
+        .into_iter()
+        .map(|cells| MathRow {
+          cells,
+          number: None,
+          label: None,
+        })
+        .collect()
+    },
+  };
+
+  return Ok(vec![DocNode::MathBlock {
+    kind,
+    rows,
+    number: env_number,
+  }]);
+}
+
+/// 非採番環境（`cases` / `matrix`）の行リストを構築する
+///
+/// 末尾の空行（行末 `\\` 由来）を除去したうえで、各行を採番なし（`number` / `label` ともに `None`）の
+/// [`MathRow`] に変換する。`cases` / `matrix` は番号を持たないため、`CounterName::Equation` を一切
+/// 消費しない（採番ありの環境と通し番号を共有しない）。
+pub(crate) fn into_unnumbered_rows(mut grid: Vec<Vec<Vec<MathNode>>>) -> Vec<MathRow> {
+  while grid.last().is_some_and(|row| is_blank_row(row)) {
+    grid.pop();
+  }
+  return grid
+    .into_iter()
+    .map(|cells| MathRow {
+      cells,
+      number: None,
+      label: None,
+    })
+    .collect();
+}
+
+/// 行が空（全セルが空白のみ）かどうかを判定する
+///
+/// 構造分割器は行末 `\\` のあとに空白テキストだけの行を 1 つ残すため、採番前にその末尾行を
+/// 除去する。空セル、または改行・スペースだけの `Text` ノードしか含まない行を空とみなす。
+fn is_blank_row(row: &[Vec<MathNode>]) -> bool {
+  return row
+    .iter()
+    .all(|cell| cell.iter().all(|node| matches!(node, MathNode::Text(t) if t.trim().is_empty())));
 }
 
 #[cfg(test)]

--- a/crates/parser/src/evaluator/environment/matrix.rs
+++ b/crates/parser/src/evaluator/environment/matrix.rs
@@ -1,0 +1,191 @@
+//! 数式環境 — `matrix`
+//!
+//! `\begin{matrix}...\end{matrix}` を [`DocNode::MathBlock`]（`kind = Matrix`）に変換します。本体は
+//! [`syntax::ParseMode::Math`] で構造化された CST を行区切り `\\` × 列区切り `&` のグリッドに分割します。
+//! 区切り括弧は環境名を分けず（pmatrix / bmatrix … を作らず）、単一 `matrix` 環境の任意引数
+//! `[delimiter=none|paren|bracket|brace|bar|dbar]` で選びます（既定 `none`）。中央揃えセルと区切り括弧の
+//! 描画は `layout` 段が [`MathEnvKind::Matrix`] に応じて確定します。
+//!
+//! `matrix` は**非採番**であり、[`read_style::CounterName::Equation`] を一切消費しません。
+//!
+//! ## 任意引数
+//!
+//! - `[delimiter=...]` — 区切り括弧の種別（`none` / `paren` / `bracket` / `brace` / `bar` / `dbar`）
+
+use document::{DocNode, MathDelimiter, MathEnvKind};
+use syntax::ast::EnvironmentView;
+
+use super::math_grid::{GridSpec, evaluate_grid, into_unnumbered_rows};
+use crate::evaluator::{
+  EvalError, Evaluator,
+  opt_args::{OptType, collect_environment_opt_args, find_string},
+};
+
+/// `matrix` 環境を評価する
+///
+/// 任意引数 `[delimiter=...]` で区切り括弧を選び（既定 `none`）、本体を `\\` で行・`&` で列に分割した
+/// 非採番の `MathRow` 列を持つ `MathBlock`（`kind = Matrix { delimiter }`）を返す。
+///
+/// # Errors
+///
+/// 未知の任意引数キー・`delimiter` の不正値・位置引数の指定、本体のセル評価失敗時にエラーを返します
+pub(super) fn matrix(view: &EnvironmentView, _evaluator: &mut Evaluator) -> Result<Vec<DocNode>, EvalError> {
+  let opt_args = collect_environment_opt_args(view, &[("delimiter", OptType::String)])?;
+  let delimiter = match find_string(opt_args, "delimiter") {
+    Some(value) => MathDelimiter::from_opt_str(&value).ok_or_else(|| EvalError::InvalidOptArgValue {
+      name: "matrix".to_string(),
+      key: "delimiter".to_string(),
+      expected: "none / paren / bracket / brace / bar / dbar".to_string(),
+      span: view.span().into(),
+    })?,
+    None => MathDelimiter::None,
+  };
+  if !view.args().is_empty() {
+    return Err(EvalError::ExtraEnvironmentArgument {
+      name: "matrix".to_string(),
+      span: view.span().into(),
+    });
+  }
+
+  let source = view.source();
+  let grid = match view.body() {
+    Some(body_node) => evaluate_grid(
+      source,
+      body_node,
+      &GridSpec {
+        allow_row_breaks: true,
+        allow_column_breaks: true,
+      },
+    )?,
+    None => Vec::new(),
+  };
+  let rows = into_unnumbered_rows(grid);
+
+  return Ok(vec![DocNode::MathBlock {
+    kind: MathEnvKind::Matrix { delimiter },
+    rows,
+    number: None,
+  }]);
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+  use bumpalo::Bump;
+  use document::{MathDelimiter, MathEnvKind};
+  use read_style::{Counters, Style};
+
+  use super::*;
+  use crate::evaluator::lookup_env_parse_mode;
+
+  fn parse<'a>(source: &'a str, arena: &'a Bump) -> Result<&'a syntax::green::GreenNode<'a>, syntax::ParserError> {
+    return syntax::parse(source, arena, lookup_env_parse_mode);
+  }
+
+  /// equation カウンタの `format` を `"{n}"` に縮約した Style
+  fn style_with_plain_equation_format() -> Style {
+    let mut counters = Counters::default();
+    counters.equation.format = "{n}".to_string();
+    return Style {
+      counters,
+      ..Default::default()
+    };
+  }
+
+  /// 結果の最初の `MathBlock` の `(delimiter, rows)` を取り出すヘルパ（kind が Matrix であることも検証）
+  fn matrix_of(result: &[DocNode]) -> (MathDelimiter, &[document::MathRow]) {
+    let DocNode::MathBlock { kind, rows, number } = &result[0] else {
+      panic!("MathBlock が期待されます: {:?}", result[0]);
+    };
+    assert!(number.is_none(), "matrix は非採番（環境番号なし）: {number:?}");
+    let MathEnvKind::Matrix { delimiter } = kind else {
+      panic!("matrix は MathEnvKind::Matrix: {kind:?}");
+    };
+    return (*delimiter, rows);
+  }
+
+  #[test]
+  fn matrix_splits_grid_default_delimiter_none_unnumbered() {
+    // Arrange — 2 行 × 2 列のグリッド（区切り指定なし）
+    let arena = Bump::new();
+    let source = r"\begin{matrix}a & b \\ c & d\end{matrix}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::new(&style_with_plain_equation_format());
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst).unwrap();
+
+    // Assert — Matrix { None }、2 行・各 2 セル・非採番
+    assert_eq!(result.len(), 1);
+    let (delimiter, rows) = matrix_of(&result);
+    assert_eq!(delimiter, MathDelimiter::None, "既定は区切りなし");
+    assert_eq!(rows.len(), 2, "2 行: {rows:?}");
+    assert!(rows.iter().all(|r| r.cells.len() == 2), "各行 2 列: {rows:?}");
+    assert!(rows.iter().all(|r| r.number.is_none()), "非採番のはず: {rows:?}");
+  }
+
+  #[test]
+  fn matrix_parses_delimiter_option() {
+    // Arrange — `[delimiter=bracket]` で角括弧を選ぶ
+    let arena = Bump::new();
+    let source = r"\begin{matrix}[delimiter=bracket]a & b \\ c & d\end{matrix}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::new(&style_with_plain_equation_format());
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst).unwrap();
+
+    // Assert
+    let (delimiter, _) = matrix_of(&result);
+    assert_eq!(delimiter, MathDelimiter::Bracket);
+  }
+
+  #[test]
+  fn matrix_rejects_unknown_delimiter_value() {
+    // Arrange — 未知の区切り値はエラー
+    let arena = Bump::new();
+    let source = r"\begin{matrix}[delimiter=angle]a & b\end{matrix}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::default();
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst);
+
+    // Assert
+    assert!(matches!(result, Err(EvalError::InvalidOptArgValue { ref key, .. }) if key == "delimiter"));
+  }
+
+  #[test]
+  fn matrix_does_not_consume_equation_counter() {
+    // Arrange — matrix は非採番。後続 equation は 1 から始まる
+    let arena = Bump::new();
+    let source = r"\begin{matrix}a & b\end{matrix}\begin{equation}e\end{equation}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::new(&style_with_plain_equation_format());
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst).unwrap();
+
+    // Assert
+    assert_eq!(result.len(), 2);
+    let DocNode::MathBlock { rows: eq_rows, .. } = &result[1] else {
+      panic!("equation の MathBlock が期待されます: {:?}", result[1]);
+    };
+    assert_eq!(eq_rows[0].number.as_deref(), Some("1"));
+  }
+
+  #[test]
+  fn matrix_rejects_unknown_opt_key() {
+    // Arrange — matrix は `[delimiter]` のみ許可。未知キーはエラー
+    let arena = Bump::new();
+    let source = r"\begin{matrix}[numbered=true]a & b\end{matrix}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::default();
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst);
+
+    // Assert
+    assert!(matches!(result, Err(EvalError::UnknownOptArgKey { ref key, .. }) if key == "numbered"));
+  }
+}

--- a/crates/parser/src/evaluator/environment/multiline.rs
+++ b/crates/parser/src/evaluator/environment/multiline.rs
@@ -1,0 +1,124 @@
+//! 数式環境 — `multiline`
+//!
+//! `\begin{multiline}...\end{multiline}` を [`DocNode::MathBlock`]（`kind = Multiline`）に変換します。
+//! 長い 1 つの式を `\\` で複数行に折り、先頭行を左・末尾行を右・中間行を中央へ配置する「階段」レイアウト
+//! を取ります（列区切り `&` は不可）。採番は **環境全体に 1 つ**だけ（縦中央配置）。実体は共通ハンドラ
+//! [`super::math_grid::evaluate_math_env`]（`NumberingMode::SingleEnv`）に委譲します。階段配置は
+//! `layout` 段が [`MathEnvKind::Multiline`] に応じて確定します。
+//!
+//! 綴りは amsmath の `multline`（`i` 抜け）ではなく正しい `multiline` を採用します（親 issue #25）。
+//!
+//! ## 任意引数
+//!
+//! - `[numbered=false]` — 環境全体を無採番にする
+
+use document::{DocNode, MathEnvKind};
+use syntax::ast::EnvironmentView;
+
+use super::math_grid::{GridSpec, NumberingMode, evaluate_math_env};
+use crate::evaluator::{EvalError, Evaluator};
+
+/// `multiline` 環境を評価する
+///
+/// 本体を `\\` で行に分割（`&` は不可）し、環境全体に 1 つだけ通し番号を発番した `MathBlock`
+/// （`kind = Multiline`）を返す。階段配置と番号の縦中央配置は `layout` 段が決める。`[numbered=false]`
+/// 指定時は採番しない。
+///
+/// # Errors
+///
+/// 未知の任意引数キー・位置引数の指定、本体への `&`（列区切り）混入、セル評価失敗時にエラーを返します
+pub(super) fn multiline(view: &EnvironmentView, evaluator: &mut Evaluator) -> Result<Vec<DocNode>, EvalError> {
+  return evaluate_math_env(
+    view,
+    evaluator,
+    MathEnvKind::Multiline,
+    &GridSpec {
+      allow_row_breaks: true,
+      allow_column_breaks: false,
+    },
+    &NumberingMode::SingleEnv,
+  );
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+  use bumpalo::Bump;
+  use document::MathEnvKind;
+  use read_style::{Counters, Style};
+
+  use super::*;
+  use crate::evaluator::lookup_env_parse_mode;
+
+  fn parse<'a>(source: &'a str, arena: &'a Bump) -> Result<&'a syntax::green::GreenNode<'a>, syntax::ParserError> {
+    return syntax::parse(source, arena, lookup_env_parse_mode);
+  }
+
+  /// equation カウンタの `format` を `"{n}"` に縮約した Style
+  fn style_with_plain_equation_format() -> Style {
+    let mut counters = Counters::default();
+    counters.equation.format = "{n}".to_string();
+    return Style {
+      counters,
+      ..Default::default()
+    };
+  }
+
+  fn block_of(result: &[DocNode]) -> (&[document::MathRow], Option<&str>) {
+    let DocNode::MathBlock { kind, rows, number } = &result[0] else {
+      panic!("MathBlock が期待されます: {:?}", result[0]);
+    };
+    assert_eq!(*kind, MathEnvKind::Multiline, "multiline は MathEnvKind::Multiline");
+    return (rows, number.as_deref());
+  }
+
+  #[test]
+  fn multiline_splits_rows_single_cell_and_numbers_whole_env_once() {
+    // Arrange — 3 行・各 1 セルの multiline。番号は環境全体に 1 つ
+    let arena = Bump::new();
+    let source = r"\begin{multiline}a + b \\ + c + d \\ + e\end{multiline}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::new(&style_with_plain_equation_format());
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst).unwrap();
+
+    // Assert — 3 行・各 1 セル・行は無採番・環境全体の番号 "1"
+    let (rows, env_number) = block_of(&result);
+    assert_eq!(rows.len(), 3, "3 行: {rows:?}");
+    assert!(rows.iter().all(|r| r.cells.len() == 1), "各行 1 セル: {rows:?}");
+    assert!(rows.iter().all(|r| r.number.is_none()), "行は無採番: {rows:?}");
+    assert_eq!(env_number, Some("1"));
+  }
+
+  #[test]
+  fn multiline_rejects_column_break() {
+    // Arrange — multiline は `&`（列区切り）を許さない
+    let arena = Bump::new();
+    let source = r"\begin{multiline}a & b\end{multiline}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::default();
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst);
+
+    // Assert
+    assert!(matches!(result, Err(EvalError::UnsupportedInMath { .. })));
+  }
+
+  #[test]
+  fn multiline_numbered_false_suppresses_numbering() {
+    // Arrange — `[numbered=false]` で環境全体の番号も出ない
+    let arena = Bump::new();
+    let source = r"\begin{multiline}[numbered=false]a + b \\ + c\end{multiline}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::new(&style_with_plain_equation_format());
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst).unwrap();
+
+    // Assert
+    let (_, env_number) = block_of(&result);
+    assert_eq!(env_number, None, "無採番のはず");
+  }
+}

--- a/crates/parser/src/evaluator/environment/split.rs
+++ b/crates/parser/src/evaluator/environment/split.rs
@@ -1,0 +1,127 @@
+//! 数式環境 — `split`
+//!
+//! `\begin{split}...\end{split}` を [`DocNode::MathBlock`]（`kind = Split`）に変換します。本体は
+//! `\\` で行・`&` で列に分割し、`align` と同じ列整列（奇数列＝右・偶数列＝左）で揃えますが、採番は
+//! **環境全体に 1 つ**だけ（縦中央配置）です。実体は共通ハンドラ
+//! [`super::math_grid::evaluate_math_env`]（`NumberingMode::SingleEnv`）に委譲します。
+//!
+//! ## 任意引数
+//!
+//! - `[numbered=false]` — 環境全体を無採番にする
+
+use document::{DocNode, MathEnvKind};
+use syntax::ast::EnvironmentView;
+
+use super::math_grid::{GridSpec, NumberingMode, evaluate_math_env};
+use crate::evaluator::{EvalError, Evaluator};
+
+/// `split` 環境を評価する
+///
+/// 本体を `\\` で行・`&` で列に分割し、環境全体に 1 つだけ通し番号を発番した `MathBlock`
+/// （`kind = Split`）を返す。番号は `layout` 段がブロック縦中央へ配置する。`[numbered=false]` 指定時は
+/// 採番しない。
+///
+/// # Errors
+///
+/// 未知の任意引数キー・位置引数の指定、本体のセル評価失敗時にエラーを返します
+pub(super) fn split(view: &EnvironmentView, evaluator: &mut Evaluator) -> Result<Vec<DocNode>, EvalError> {
+  return evaluate_math_env(
+    view,
+    evaluator,
+    MathEnvKind::Split,
+    &GridSpec {
+      allow_row_breaks: true,
+      allow_column_breaks: true,
+    },
+    &NumberingMode::SingleEnv,
+  );
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+  use bumpalo::Bump;
+  use document::MathEnvKind;
+  use read_style::{Counters, Style};
+
+  use super::*;
+  use crate::evaluator::lookup_env_parse_mode;
+
+  fn parse<'a>(source: &'a str, arena: &'a Bump) -> Result<&'a syntax::green::GreenNode<'a>, syntax::ParserError> {
+    return syntax::parse(source, arena, lookup_env_parse_mode);
+  }
+
+  /// equation カウンタの `format` を `"{n}"` に縮約した Style
+  fn style_with_plain_equation_format() -> Style {
+    let mut counters = Counters::default();
+    counters.equation.format = "{n}".to_string();
+    return Style {
+      counters,
+      ..Default::default()
+    };
+  }
+
+  /// 最初の `DocNode::MathBlock`（`Split`）を分解して (`rows`, `env_number`) を返す
+  fn block_of(result: &[DocNode]) -> (&[document::MathRow], Option<&str>) {
+    let DocNode::MathBlock { kind, rows, number } = &result[0] else {
+      panic!("MathBlock が期待されます: {:?}", result[0]);
+    };
+    assert_eq!(*kind, MathEnvKind::Split, "split は MathEnvKind::Split");
+    return (rows, number.as_deref());
+  }
+
+  #[test]
+  fn split_aligns_columns_and_numbers_whole_env_once() {
+    // Arrange — 2 行 × 2 列の split。番号は環境全体に 1 つ
+    let arena = Bump::new();
+    let source = r"\begin{split}a &= b \\ &= c\end{split}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::new(&style_with_plain_equation_format());
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst).unwrap();
+
+    // Assert — 2 行・各行は無採番・環境全体の番号が "1"
+    let (rows, env_number) = block_of(&result);
+    assert_eq!(rows.len(), 2, "2 行: {rows:?}");
+    assert!(rows.iter().all(|r| r.number.is_none()), "行は無採番: {rows:?}");
+    assert_eq!(env_number, Some("1"), "環境全体に 1 つの番号");
+  }
+
+  #[test]
+  fn split_consumes_single_counter_value() {
+    // Arrange — split（環境 1 つ分）の後の equation は 2 になる（split は 1 を 1 回だけ消費）
+    let arena = Bump::new();
+    let source = r"\begin{split}a &= b \\ &= c\end{split}\begin{equation}d\end{equation}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::new(&style_with_plain_equation_format());
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst).unwrap();
+
+    // Assert — split の env number = 1、equation = 2
+    let (_, env_number) = block_of(&result);
+    assert_eq!(env_number, Some("1"));
+    let DocNode::MathBlock { rows: eq_rows, .. } = &result[1] else {
+      panic!("equation の MathBlock が期待されます: {:?}", result[1]);
+    };
+    assert_eq!(eq_rows[0].number.as_deref(), Some("2"));
+  }
+
+  #[test]
+  fn split_numbered_false_suppresses_numbering() {
+    // Arrange — `[numbered=false]` で環境全体の番号も出ない
+    let arena = Bump::new();
+    let source = r"\begin{split}[numbered=false]a &= b \\ &= c\end{split}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::new(&style_with_plain_equation_format());
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst).unwrap();
+
+    // Assert
+    let (rows, env_number) = block_of(&result);
+    assert!(rows.iter().all(|r| r.number.is_none()));
+    assert_eq!(env_number, None, "無採番のはず");
+  }
+}

--- a/crates/parser/src/evaluator/error.rs
+++ b/crates/parser/src/evaluator/error.rs
@@ -236,6 +236,22 @@ pub enum EvalError {
     span: SourceSpan,
   },
 
+  /// `cases` 環境の 1 行が 3 列以上に分割された場合
+  ///
+  /// `cases` は「式 & 条件」の 2 列固定なので、`&` が 1 行に 2 個以上現れるとエラーにする。
+  #[error("cases 環境の行は 2 列までです（{found} 列が指定されています）")]
+  #[diagnostic(
+    code(parser::eval::cases_column_overflow),
+    help("cases の各行は `式 & 条件` の 2 列までです。3 列以上が必要なら matrix / align を使ってください")
+  )]
+  CasesColumnOverflow {
+    /// 実際に分割された列数
+    found: usize,
+    /// 環境のソース位置
+    #[label("この行の列が多すぎます")]
+    span: SourceSpan,
+  },
+
   /// 環境の本体に許可されていないコマンドが出現した場合
   #[error("環境 {env} 内で許可されていないコマンドです: \\{name}")]
   #[diagnostic(

--- a/crates/parser/src/evaluator/opt_args.rs
+++ b/crates/parser/src/evaluator/opt_args.rs
@@ -87,6 +87,17 @@ pub(crate) fn find_color(opt_args: Vec<(String, OptValue)>, key: &str) -> Option
   });
 }
 
+/// 収集済み任意引数から指定キーの真偽値を取り出す
+///
+/// `[numbered=false]` / `[breakable=false]` のような単一の bool キーを取り出す典型パターン用。
+/// キーが存在しない、または値が bool 型でない場合は `None` を返す。
+pub(crate) fn find_bool(opt_args: Vec<(String, OptValue)>, key: &str) -> Option<bool> {
+  return opt_args.into_iter().find_map(|(k, value)| match value {
+    OptValue::Bool(b) if k == key => Some(b),
+    _ => None,
+  });
+}
+
 /// `CommandView` 用の薄いラッパ
 ///
 /// # Errors

--- a/crates/types/src/math.rs
+++ b/crates/types/src/math.rs
@@ -1,6 +1,6 @@
 //! 数式環境の種別 [`MathEnvKind`] と区切り括弧 [`MathDelimiter`]。
 //!
-//! ディスプレイ数式環境（`equation` / `align` / `gather` / `cases` / `matrix`）の
+//! ディスプレイ数式環境（`equation` / `align` / `gather` / `split` / `multiline` / `cases` / `matrix`）の
 //! 種別を表す共通型。`document`（IR）・`lowering`（`LayoutNode`）・`layout`（組版）が
 //! 共有するため、依存の基盤である本クレートに置く。`parser` が環境名から決定し、
 //! `layout` 段の列整列・区切り括弧・行採番まで透過的に伝播する。
@@ -17,6 +17,10 @@ pub enum MathEnvKind {
   Align,
   /// `gather` — 複数行・各行中央寄せ・行ごと採番
   Gather,
+  /// `split` — 複数行・`&` 整列・環境全体に 1 つだけ採番（縦中央）
+  Split,
+  /// `multiline` — 複数行・単一列・先頭=左 / 末尾=右 / 中間=中央の階段配置・環境全体に 1 つだけ採番（縦中央）
+  Multiline,
   /// `cases` — 左波括弧 + 2 列・非採番
   Cases,
   /// `matrix` — グリッド整列 + 区切り括弧・非採番
@@ -44,4 +48,45 @@ pub enum MathDelimiter {
   Bar,
   /// 二重縦棒 `‖ ‖`
   DoubleBar,
+}
+
+impl MathDelimiter {
+  /// `matrix` 環境の `[delimiter=...]` オプション値文字列を [`MathDelimiter`] に変換する
+  ///
+  /// 受理する値は `none` / `paren` / `bracket` / `brace` / `bar` / `dbar`（大小無視）。
+  /// 未知の値には `None` を返す（呼び出し側がエラーにする）。
+  #[must_use]
+  pub fn from_opt_str(value: &str) -> Option<Self> {
+    return match value.trim().to_ascii_lowercase().as_str() {
+      "none" => Some(MathDelimiter::None),
+      "paren" => Some(MathDelimiter::Paren),
+      "bracket" => Some(MathDelimiter::Bracket),
+      "brace" => Some(MathDelimiter::Brace),
+      "bar" => Some(MathDelimiter::Bar),
+      "dbar" => Some(MathDelimiter::DoubleBar),
+      _ => None,
+    };
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::MathDelimiter;
+
+  #[test]
+  fn from_opt_str_maps_known_values_case_insensitively() {
+    // Arrange & Act & Assert — 既知の値はすべて対応する変種に（大小無視で）変換される
+    assert_eq!(MathDelimiter::from_opt_str("none"), Some(MathDelimiter::None));
+    assert_eq!(MathDelimiter::from_opt_str("paren"), Some(MathDelimiter::Paren));
+    assert_eq!(MathDelimiter::from_opt_str("BRACKET"), Some(MathDelimiter::Bracket));
+    assert_eq!(MathDelimiter::from_opt_str(" brace "), Some(MathDelimiter::Brace));
+    assert_eq!(MathDelimiter::from_opt_str("bar"), Some(MathDelimiter::Bar));
+    assert_eq!(MathDelimiter::from_opt_str("dbar"), Some(MathDelimiter::DoubleBar));
+  }
+
+  #[test]
+  fn from_opt_str_rejects_unknown_value() {
+    // Arrange & Act & Assert — 未知の値は None
+    assert_eq!(MathDelimiter::from_opt_str("angle"), None);
+  }
 }

--- a/tests/text/align.sei
+++ b/tests/text/align.sei
@@ -1,0 +1,26 @@
+\section{整列数式のサンプル}
+
+align 環境は複数行の式を列区切りの位置で揃え、各行に式番号を付ける動作確認用フィクスチャ。
+
+\begin{align}
+a + b &= c \\
+x &= y + z \\
+\alpha &= \beta + \gamma
+\end{align}
+
+\section{1 行の align}
+
+1 行だけでも採番される。
+
+\begin{align}
+f &= m a
+\end{align}
+
+\section{上付き・下付きを含む align}
+
+各セル内で上付き・下付き・記号が評価される。
+
+\begin{align}
+E &= m c^2 \\
+a_i &= b_i + c_i
+\end{align}

--- a/tests/text/cases.sei
+++ b/tests/text/cases.sei
@@ -1,0 +1,19 @@
+\section{場合分け (cases)}
+
+cases 環境は左の大波括弧で囲んだ「式 & 条件」の 2 列を左揃えに並べる動作確認用フィクスチャ。
+番号は付かない。
+
+\begin{cases}
+x & x > 0 \\
+-x & x < 0
+\end{cases}
+
+\section{3 行の cases}
+
+行数が増えても左波括弧がグリッド全体の高さに合わせて拡大される。
+
+\begin{cases}
+1 & n = 0 \\
+n & n = 1 \\
+a + b & n > 1
+\end{cases}

--- a/tests/text/gather.sei
+++ b/tests/text/gather.sei
@@ -1,0 +1,18 @@
+\section{中央寄せ数式 (gather)}
+
+gather 環境は複数行の式を各行中央に揃え、各行に式番号を付ける動作確認用フィクスチャ。
+
+\begin{gather}
+a = b + c \\
+x = y \\
+\alpha + \beta = \gamma
+\end{gather}
+
+\section{無採番の gather}
+
+numbered=false で採番を抑制できる。
+
+\begin{gather}[numbered=false]
+p = q \\
+r = s
+\end{gather}

--- a/tests/text/matrix.sei
+++ b/tests/text/matrix.sei
@@ -1,0 +1,23 @@
+\section{行列 (matrix)}
+
+matrix 環境は & で列・\\ で行のグリッドを中央揃えに組む動作確認用フィクスチャ。
+区切り括弧は任意引数 delimiter で選ぶ（既定は括弧なし）。番号は付かない。
+
+\begin{matrix}
+a & b \\
+c & d
+\end{matrix}
+
+\section{角括弧つき行列}
+
+delimiter=bracket で角括弧、delimiter=paren で丸括弧を付けられる。
+
+\begin{matrix}[delimiter=bracket]
+1 & 0 \\
+0 & 1
+\end{matrix}
+
+\begin{matrix}[delimiter=paren]
+x & y & z \\
+u & v & w
+\end{matrix}

--- a/tests/text/multiline.sei
+++ b/tests/text/multiline.sei
@@ -1,0 +1,16 @@
+\section{多行数式 (multiline)}
+
+multiline 環境は 1 つの長い式を折り返し、先頭行を左・末尾行を右・中間行を中央に配置して、環境全体に式番号を 1 つ付ける動作確認用フィクスチャ。
+
+\begin{multiline}
+a + b + c + d + e \\
++ f + g + h + i + j \\
++ k + l + m
+\end{multiline}
+
+\section{無採番の multiline}
+
+\begin{multiline}[numbered=false]
+x + y + z \\
++ u + v + w
+\end{multiline}

--- a/tests/text/split.sei
+++ b/tests/text/split.sei
@@ -1,0 +1,16 @@
+\section{分割数式 (split)}
+
+split 環境は 1 つの長い式を複数行に分け、列区切りの位置で揃えつつ、環境全体に式番号を 1 つだけ付ける動作確認用フィクスチャ。
+
+\begin{split}
+a &= b + c + d \\
+&= e + f \\
+&= g
+\end{split}
+
+\section{無採番の split}
+
+\begin{split}[numbered=false]
+u &= v + w \\
+&= x
+\end{split}


### PR DESCRIPTION
## 概要

epic #25 を完了する。#40 の**測定済みグリッド Block** 基盤の上に、amsmath 相当の複数行・整列数式環境を実装した。`equation` も新グリッド経路で中央寄せされる。

各環境は基盤グリッド（行 × 列 × 列整列 × 採番 × 区切り括弧）の構成違いとして実装している。

| 環境 | 列整列 | 採番 | 区切り括弧 |
|---|---|---|---|
| `align` (#41) | `&` 整列（奇数列右・偶数列左） | 各行 | — |
| `gather` (#44) | 中央（`&` 不可） | 各行 | — |
| `split` (#71) | `&` 整列 | 環境全体に 1（縦中央） | — |
| `multiline` (#72) | 左→中央→右の階段（`&` 不可） | 環境全体に 1（縦中央） | — |
| `cases` (#42) | 2 列固定・左揃え | 非採番 | 左波括弧 |
| `matrix` (#43) | 中央 | 非採番 | `[delimiter=...]` |

## 設計ポイント

- **採番トグル**は `*` 接尾辞ではなくオプション引数 `[numbered=false]` で表す（Seiran の引数明示・宣言型回避の原則に整合）。採番ありの環境でのみ意味を持つ。
- **matrix の括弧**は環境名を増やさず単一 `matrix` + `[delimiter=none|paren|bracket|brace|bar|dbar]`（既定 `none`）。
- **cases / matrix は非採番**で、`equation` カウンタを一切消費しない（標準採番ハンドラ `evaluate_math_env` ではなく専用ハンドラ）。cases は「式 & 条件」の 2 列固定で、3 列以上は `EvalError::CasesColumnOverflow`。
- **区切り括弧の描画**は本体 Atom を左右の括弧で挟んで包み直す方式で `layout` 段に閉じており、`lowering` / `hlist` / `pdf_gen` に変更は不要。当面は数式フォントのグリフをグリッド高に合わせ**一様拡大した 1 グリフ**で描く（OpenType MATH 由来の伸縮は read-fonts 未対応のため後送り → #73）。

## テスト

- parser: align/gather/split/multiline/cases/matrix のユニットテスト（行・列分割、採番、`[numbered=false]`、cases の列数超過、matrix の `[delimiter]` 解釈・不正値、非採番でのカウンタ非消費）
- layout: `cell_align` の環境別揃え、`delimiter_glyphs` の括弧マッピング
- types: `MathDelimiter::from_opt_str`
- lowering: `tests/text/{align,gather,split,multiline,cases,matrix}.sei` の smoke テスト
- 6 環境すべてを実際に PDF レンダリングして、整列・採番・区切り括弧（グリッド高に合わせた拡大）を目視確認

`cargo +nightly fmt --check` / `cargo clippy --all-targets --all-features -- -D warnings` / `cargo test` すべてグリーン（pre-commit フック通過）。

## 関連 / follow-up

- Closes #25, Closes #41, Closes #42, Closes #43, Closes #44, Closes #71, Closes #72
- follow-up: #73（区切り括弧の OpenType MATH 伸縮対応）、#74（行単位の採番制御 = `\notag` 相当）
- フィクスチャは `\geq` / `\leq` 未実装のため `<` / `>` を直書きしている（記号網羅は #26）

🤖 Generated with [Claude Code](https://claude.com/claude-code)