### PR TITLE
数式: 太字スクリプト・太字フラクトゥールに対応 (#81)

### DIFF
--- a/crates/document/src/math.rs
+++ b/crates/document/src/math.rs
@@ -80,6 +80,10 @@ pub enum MathStyle {
   Script,
   /// `\mathfraktur` — フラクトゥール（ドイツ文字, ℌ ℑ ℜ 等）
   Fraktur,
+  /// `\mathscriptbold` — 太字スクリプト（bold roundhand, 花文字の太字）
+  ScriptBold,
+  /// `\mathfrakturbold` — 太字フラクトゥール（bold ドイツ文字）
+  FrakturBold,
 }
 
 /// ディスプレイ数式環境の 1 行
@@ -118,6 +122,8 @@ impl MathStyle {
       "mathdoublestruck" => Some(MathStyle::DoubleStruck),
       "mathscript" => Some(MathStyle::Script),
       "mathfraktur" => Some(MathStyle::Fraktur),
+      "mathscriptbold" => Some(MathStyle::ScriptBold),
+      "mathfrakturbold" => Some(MathStyle::FrakturBold),
       _ => None,
     };
   }
@@ -193,7 +199,7 @@ mod tests {
 
   #[test]
   fn math_style_from_command_name_resolves_all_styles() {
-    // Arrange & Act & Assert — 9 個のスタイルコマンドが正しく解決される
+    // Arrange & Act & Assert — 14 個のスタイルコマンドが正しく解決される
     assert_eq!(MathStyle::from_command_name("mathserif"), Some(MathStyle::Serif));
     assert_eq!(MathStyle::from_command_name("mathitalic"), Some(MathStyle::Italic));
     assert_eq!(MathStyle::from_command_name("mathbold"), Some(MathStyle::Bold));
@@ -206,6 +212,8 @@ mod tests {
     assert_eq!(MathStyle::from_command_name("mathdoublestruck"), Some(MathStyle::DoubleStruck));
     assert_eq!(MathStyle::from_command_name("mathscript"), Some(MathStyle::Script));
     assert_eq!(MathStyle::from_command_name("mathfraktur"), Some(MathStyle::Fraktur));
+    assert_eq!(MathStyle::from_command_name("mathscriptbold"), Some(MathStyle::ScriptBold));
+    assert_eq!(MathStyle::from_command_name("mathfrakturbold"), Some(MathStyle::FrakturBold));
   }
 
   #[test]

--- a/crates/lowering/src/math.rs
+++ b/crates/lowering/src/math.rs
@@ -478,6 +478,36 @@ mod tests {
   }
 
   #[test]
+  fn lower_math_text_script_bold_maps_contiguous_block() {
+    // Arrange & Act — \mathscriptbold{AZaz} 相当: 大文字・小文字とも連続（穴なし）
+    let nodes = lower_math_text("AZaz", 12.0, Some(MathStyle::ScriptBold));
+
+    // Assert — A→U+1D4D0, Z→U+1D4E9, a→U+1D4EA, z→U+1D503
+    assert_eq!(nodes.len(), 1);
+    match &nodes[0] {
+      LayoutNode::Text(t, _) => {
+        assert_eq!(t, "\u{1D4D0}\u{1D4E9}\u{1D4EA}\u{1D503}");
+      },
+      other => panic!("Math Text を期待: {other:?}"),
+    }
+  }
+
+  #[test]
+  fn lower_math_text_fraktur_bold_maps_contiguous_block() {
+    // Arrange & Act — \mathfrakturbold{AZaz} 相当: 大文字・小文字とも連続（穴なし）
+    let nodes = lower_math_text("AZaz", 12.0, Some(MathStyle::FrakturBold));
+
+    // Assert — A→U+1D56C, Z→U+1D585, a→U+1D586, z→U+1D59F
+    assert_eq!(nodes.len(), 1);
+    match &nodes[0] {
+      LayoutNode::Text(t, _) => {
+        assert_eq!(t, "\u{1D56C}\u{1D585}\u{1D586}\u{1D59F}");
+      },
+      other => panic!("Math Text を期待: {other:?}"),
+    }
+  }
+
+  #[test]
   fn lower_math_node_styled_propagates_into_frac_body() {
     // Arrange — \mathbold{\frac{a}{b}}: 内側 frac の a と b は bold で変換される
     let node = MathNode::Styled {

--- a/crates/lowering/src/math/alphanumeric.rs
+++ b/crates/lowering/src/math/alphanumeric.rs
@@ -131,6 +131,14 @@ pub(super) fn translate_math_char(ch: char, style: Option<MathStyle>) -> char {
       // フラクトゥール: 大文字に 5 個の穴（ℭ ℌ ℑ ℜ ℨ）。小文字は連続。数字・Greek は素通し
       return map_ascii(ch, 0x1d504, 0x1d51e, fraktur_hole);
     },
+    Some(MathStyle::ScriptBold) => {
+      // 太字スクリプト: 大文字・小文字とも連続（穴なし）。数字・Greek は Unicode 未定義のため素通し
+      return map_ascii(ch, 0x1d4d0, 0x1d4ea, no_hole);
+    },
+    Some(MathStyle::FrakturBold) => {
+      // 太字フラクトゥール: 大文字・小文字とも連続（穴なし）。数字・Greek は素通し
+      return map_ascii(ch, 0x1d56c, 0x1d586, no_hole);
+    },
   }
 }
 
@@ -390,5 +398,29 @@ mod tests {
     assert_eq!(translate_math_char('g', style), '\u{210A}'); // ℊ (穴)
     assert_eq!(translate_math_char('o', style), '\u{2134}'); // ℴ (穴)
     assert_eq!(translate_math_char('1', style), '1', "スクリプト数字は素通し");
+  }
+
+  #[test]
+  fn translate_script_bold_maps_contiguous_block() {
+    // Arrange & Act & Assert — 太字スクリプト: 大文字・小文字とも連続（穴なし）、base 先頭/末尾を確認
+    let style = Some(MathStyle::ScriptBold);
+    assert_eq!(translate_math_char('A', style), '\u{1D4D0}'); // 大文字 base 先頭
+    assert_eq!(translate_math_char('Z', style), '\u{1D4E9}'); // 大文字 base 末尾
+    assert_eq!(translate_math_char('a', style), '\u{1D4EA}'); // 小文字 base 先頭
+    assert_eq!(translate_math_char('z', style), '\u{1D503}'); // 小文字 base 末尾
+    assert_eq!(translate_math_char('1', style), '1', "太字スクリプト数字は素通し");
+    assert_eq!(translate_math_char('α', style), 'α', "太字スクリプト Greek は Unicode 未定義のため素通し");
+  }
+
+  #[test]
+  fn translate_fraktur_bold_maps_contiguous_block() {
+    // Arrange & Act & Assert — 太字フラクトゥール: 大文字・小文字とも連続（穴なし）、base 先頭/末尾を確認
+    let style = Some(MathStyle::FrakturBold);
+    assert_eq!(translate_math_char('A', style), '\u{1D56C}'); // 大文字 base 先頭
+    assert_eq!(translate_math_char('Z', style), '\u{1D585}'); // 大文字 base 末尾
+    assert_eq!(translate_math_char('a', style), '\u{1D586}'); // 小文字 base 先頭
+    assert_eq!(translate_math_char('z', style), '\u{1D59F}'); // 小文字 base 末尾
+    assert_eq!(translate_math_char('1', style), '1', "太字フラクトゥール数字は素通し");
+    assert_eq!(translate_math_char('α', style), 'α', "太字フラクトゥール Greek は Unicode 未定義のため素通し");
   }
 }

--- a/crates/parser/tests/evaluate.rs
+++ b/crates/parser/tests/evaluate.rs
@@ -447,11 +447,13 @@ fn evaluate_inline_math_styled_sans_bold_italic_with_greek() {
 
 #[test]
 fn evaluate_inline_math_styled_math_alphabets_resolve() {
-  // Arrange — 数学字体 4 コマンドが対応する MathStyle の Styled に解決される
-  let cases: [(&str, MathStyle); 3] = [
+  // Arrange — 数学字体 5 コマンドが対応する MathStyle の Styled に解決される
+  let cases: [(&str, MathStyle); 5] = [
     ("mathdoublestruck", MathStyle::DoubleStruck),
     ("mathscript", MathStyle::Script),
     ("mathfraktur", MathStyle::Fraktur),
+    ("mathscriptbold", MathStyle::ScriptBold),
+    ("mathfrakturbold", MathStyle::FrakturBold),
   ];
 
   for (name, expected) in cases {

--- a/tests/text/equation.sei
+++ b/tests/text/equation.sei
@@ -33,3 +33,5 @@ e^{i \pi} + 1 = 0
 Letterlike Symbols に散る穴を含めて正しいグリフへ変換される。
 
 スクリプト（花文字）$\mathscript{ABFHL}$ も大文字の穴を含めて変換される。
+
+太字スクリプト $\mathscriptbold{ABC}$ と太字フラクトゥール $\mathfrakturbold{abc}$ は太字字形で出力される。


### PR DESCRIPTION
## 概要

太字スクリプト `\mathscriptbold` と太字フラクトゥール `\mathfrakturbold` の 2 字体を追加し、
Unicode Mathematical Alphanumeric Symbols の数式字体を**完全網羅**しました。Closes #81。

## 背景

#69 で黒板太字・スクリプト・フラクトゥールを実装済みで、残る Unicode 数式字体はこの太字 2 種のみでした。
両字体は #69 の非太字版と異なり **Letterlike Symbols の穴が一切なく**（大文字 26 + 小文字 26 が連続
ブロックで完結、STIX Two Math で実測：欠落 0・tofu なし）、数字・Greek は Unicode に該当字体が存在しない
ため素通しです。よって穴テーブルは不要で、既存の `map_ascii(..., no_hole)` を呼ぶだけで足ります。

## 変更内容

- **document** (`crates/document/src/math.rs`): `MathStyle` に `ScriptBold` / `FrakturBold` を追加、
  `from_command_name` に解決アームを追加
- **lowering** (`crates/lowering/src/math/alphanumeric.rs`): `translate_math_char` に 2 アーム
  （base `U+1D4D0` / `U+1D586`、ともに `no_hole`）
- **テスト**: alphanumeric の base 先頭/末尾の単体テスト、lowering 結合テスト、
  parser 結合テスト（`from_command_name` 解決）を追加
- **フィクスチャ**: `tests/text/equation.sei` に確認行を追記
- `font` / `layout` / `pdf_gen` は無改修

## コマンド名

既存の `\mathsansbold`（family→weight 語順）に合わせ `\mathscriptbold` / `\mathfrakturbold` を採用。

## 受け入れ条件

- [x] `$\mathscriptbold{ABC}$` `$\mathfrakturbold{abc}$` が太字字形の PDF を生成
  （`config/config.toml` の math フォント STIX Two Math で E2E ビルド確認、全 52 グリフ実在を確認）
- [x] 単体・結合テスト追加（`cargo test` 全緑）
- [x] `cargo clippy` 警告ゼロ・`cargo +nightly fmt` 整形済み

## 検証

```sh
cargo test -p document -p lowering -p parser   # 新規 4 件含め全緑
cargo run -- build -c config/config.toml       # equation.sei → PDF 生成成功
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)