### PR TITLE
数式記号を amssymb 相当に拡充し SYMBOL_MAP + MathClass 基盤を確立 (#26)

### DIFF
--- a/crates/parser/src/evaluator/command.rs
+++ b/crates/parser/src/evaluator/command.rs
@@ -5,10 +5,12 @@
 //!
 //! ## コマンドの追加方法
 //!
-//! 新しいコマンドを追加するには、以下の手順に従います:
+//! コマンドは **機能コマンド**（`COMMAND_MAP`）と **記号コマンド**（[`symbol::SYMBOL_MAP`]）に
+//! 分かれます。記号（ギリシャ文字・数学記号）は `SYMBOL_MAP` に置き、`COMMAND_MAP` には
+//! 制御・書体・色・見出し・参照・リンクといった機能コマンドだけを置きます。
 //!
-//! 1. **単一文字コマンド**（`\alpha` 等）:
-//!    `COMMAND_MAP` に `"name" => CommandKind::SingleChar('文字')` を追加するだけ。
+//! 1. **記号コマンド**（`\alpha` `\leq` 等）:
+//!    [`symbol::SYMBOL_MAP`] に `"name" => MathSymbol::new('文字', MathClass::Class)` を追加するだけ。
 //!
 //! 2. **書体指定コマンド**（`\bold` 等）:
 //!    `COMMAND_MAP` に `"name" => CommandKind::StyledText(FontKind::Variant)` を追加するだけ。
@@ -25,7 +27,7 @@ use phf::phf_map;
 use syntax::ast::CommandView;
 use types::FontKind;
 
-use crate::evaluator::{EvalError, Evaluator, opt_args::collect_command_opt_args};
+use crate::evaluator::{EvalError, Evaluator, command::symbol::SYMBOL_MAP, opt_args::collect_command_opt_args};
 
 pub(crate) mod cite;
 mod control;
@@ -33,6 +35,7 @@ mod headline;
 pub(crate) mod inline;
 pub(crate) mod link;
 pub(crate) mod ref_;
+pub(crate) mod symbol;
 
 /// コマンドの実行結果
 ///
@@ -67,8 +70,6 @@ pub(crate) enum CommandKind {
   /// 色は書体（`FontKind`）と直交する属性なので `StyledText` とは別経路で扱い、
   /// ネスト時は内側の `color` が外側を上書きする。
   ColoredText,
-  /// 引数なしで単一文字を出力するコマンド（ギリシャ文字・数学記号）
-  SingleChar(char),
   /// `\ref{label}` — 相互参照のスタブを生成し、pass2 で解決する
   Ref,
   /// `\cite{key}` — 文献引用のスタブを生成し、pass2 でキー存在を検証する
@@ -77,8 +78,6 @@ pub(crate) enum CommandKind {
   Url,
   /// `\href[url=uri]{表示}` — 表示テキストと外部 URI を別に指定する外部リンク
   Href,
-  /// 未定義のコマンド
-  Undefined,
 }
 
 impl CommandKind {
@@ -93,8 +92,6 @@ impl CommandKind {
 
       Self::ColoredText => inline::colored_text(view).map(CommandResult::Inline),
 
-      Self::SingleChar(ch) => single_char(view, ch).map(CommandResult::Inline),
-
       Self::Ref => ref_::ref_command(view).map(CommandResult::Inline),
 
       Self::Cite => cite::cite_command(view).map(CommandResult::Inline),
@@ -102,11 +99,6 @@ impl CommandKind {
       Self::Url => link::url_command(view).map(CommandResult::Inline),
 
       Self::Href => link::href_command(view).map(CommandResult::Inline),
-
-      Self::Undefined => Err(EvalError::UnknownCommand {
-        name: view.name().to_string(),
-        span: view.span().into(),
-      }),
     }
   }
 }
@@ -171,105 +163,7 @@ pub(crate) static COMMAND_MAP: phf::Map<&'static str, CommandKind> = phf_map! {
   "paragraph" => CommandKind::Headline(HeadingLevel::Paragraph),
   "subparagraph" => CommandKind::Headline(HeadingLevel::Subparagraph),
 
-  // ギリシャ文字（大文字）
-  "Alpha" => CommandKind::SingleChar('\u{0391}'),
-  "Beta" => CommandKind::SingleChar('\u{0392}'),
-  "Gamma" => CommandKind::SingleChar('\u{0393}'),
-  "Delta" => CommandKind::SingleChar('\u{0394}'),
-  "Epsilon" => CommandKind::SingleChar('\u{0395}'),
-  "Zeta" => CommandKind::SingleChar('\u{0396}'),
-  "Eta" => CommandKind::SingleChar('\u{0397}'),
-  "Theta" => CommandKind::SingleChar('\u{0398}'),
-  "Iota" => CommandKind::SingleChar('\u{0399}'),
-  "Kappa" => CommandKind::SingleChar('\u{039A}'),
-  "Lambda" => CommandKind::SingleChar('\u{039B}'),
-  "Mu" => CommandKind::SingleChar('\u{039C}'),
-  "Nu" => CommandKind::SingleChar('\u{039D}'),
-  "Xi" => CommandKind::SingleChar('\u{039E}'),
-  "Omicron" => CommandKind::SingleChar('\u{039F}'),
-  "Pi" => CommandKind::SingleChar('\u{03A0}'),
-  "Rho" => CommandKind::SingleChar('\u{03A1}'),
-  "Sigma" => CommandKind::SingleChar('\u{03A3}'),
-  "Tau" => CommandKind::SingleChar('\u{03A4}'),
-  "Upsilon" => CommandKind::SingleChar('\u{03A5}'),
-  "Phi" => CommandKind::SingleChar('\u{03A6}'),
-  "Chi" => CommandKind::SingleChar('\u{03A7}'),
-  "Psi" => CommandKind::SingleChar('\u{03A8}'),
-  "Omega" => CommandKind::SingleChar('\u{03A9}'),
-
-  // ギリシャ文字（小文字）
-  "alpha" => CommandKind::SingleChar('\u{03B1}'),
-  "beta" => CommandKind::SingleChar('\u{03B2}'),
-  "gamma" => CommandKind::SingleChar('\u{03B3}'),
-  "delta" => CommandKind::SingleChar('\u{03B4}'),
-  "epsilon" => CommandKind::SingleChar('\u{03B5}'),
-  "varepsilon" => CommandKind::SingleChar('\u{03F5}'),
-  "zeta" => CommandKind::SingleChar('\u{03B6}'),
-  "eta" => CommandKind::SingleChar('\u{03B7}'),
-  "theta" => CommandKind::SingleChar('\u{03B8}'),
-  "vartheta" => CommandKind::SingleChar('\u{03D1}'),
-  "iota" => CommandKind::SingleChar('\u{03B9}'),
-  "kappa" => CommandKind::SingleChar('\u{03BA}'),
-  "varkappa" => CommandKind::SingleChar('\u{03F0}'),
-  "lambda" => CommandKind::SingleChar('\u{03BB}'),
-  "mu" => CommandKind::SingleChar('\u{03BC}'),
-  "nu" => CommandKind::SingleChar('\u{03BD}'),
-  "xi" => CommandKind::SingleChar('\u{03BE}'),
-  "omicron" => CommandKind::SingleChar('\u{03BF}'),
-  "pi" => CommandKind::SingleChar('\u{03C0}'),
-  "varpi" => CommandKind::SingleChar('\u{03D6}'),
-  "rho" => CommandKind::SingleChar('\u{03C1}'),
-  "varrho" => CommandKind::SingleChar('\u{03F1}'),
-  "sigma" => CommandKind::SingleChar('\u{03C3}'),
-  "varsigma" => CommandKind::SingleChar('\u{03C2}'),
-  "tau" => CommandKind::SingleChar('\u{03C4}'),
-  "upsilon" => CommandKind::SingleChar('\u{03C5}'),
-  "phi" => CommandKind::SingleChar('\u{03C6}'),
-  "chi" => CommandKind::SingleChar('\u{03C7}'),
-  "psi" => CommandKind::SingleChar('\u{03C8}'),
-  "omega" => CommandKind::SingleChar('\u{03C9}'),
-
-  // 数学記号
-  "forall" => CommandKind::SingleChar('\u{2200}'),
-  "complement" => CommandKind::SingleChar('\u{2201}'),
-  "partial" => CommandKind::SingleChar('\u{2202}'),
-  "exists" => CommandKind::SingleChar('\u{2203}'),
-  "notexists" => CommandKind::SingleChar('\u{2204}'),
-  "emptyset" => CommandKind::SingleChar('\u{2205}'),
-  "increment" => CommandKind::SingleChar('\u{2206}'),
-  "nabla" => CommandKind::SingleChar('\u{2207}'),
-  "in" => CommandKind::SingleChar('\u{2208}'),
-  "notin" => CommandKind::SingleChar('\u{2209}'),
-  "ni" => CommandKind::SingleChar('\u{220B}'),
-  "notni" => CommandKind::SingleChar('\u{220C}'),
-  "qed" => CommandKind::SingleChar('\u{220E}'),
-  "prod" => CommandKind::SingleChar('\u{220F}'),
-  "coprod" => CommandKind::SingleChar('\u{2210}'),
-  "sum" => CommandKind::SingleChar('\u{2211}'),
-  "minus" => CommandKind::SingleChar('\u{2212}'),
-  "mp" => CommandKind::SingleChar('\u{2213}'),
-  "dotplus" => CommandKind::SingleChar('\u{2214}'),
-  "slash" => CommandKind::SingleChar('\u{2215}'),
-  "surd" => CommandKind::SingleChar('\u{221A}'),
-  "propto" => CommandKind::SingleChar('\u{221D}'),
-  "infty" => CommandKind::SingleChar('\u{221E}'),
-  "rightangle" => CommandKind::SingleChar('\u{221F}'),
-  "angle" => CommandKind::SingleChar('\u{2220}'),
-  "parallel" => CommandKind::SingleChar('\u{2225}'),
-  "notparallel" => CommandKind::SingleChar('\u{2226}'),
-  "land" => CommandKind::SingleChar('\u{2227}'),
-  "lor" => CommandKind::SingleChar('\u{2228}'),
-  "cap" => CommandKind::SingleChar('\u{2229}'),
-  "cup" => CommandKind::SingleChar('\u{222A}'),
-  "int" => CommandKind::SingleChar('\u{222B}'),
-  "iint" => CommandKind::SingleChar('\u{222C}'),
-  "iiint" => CommandKind::SingleChar('\u{222D}'),
-  "oint" => CommandKind::SingleChar('\u{222E}'),
-  "oiint" => CommandKind::SingleChar('\u{222F}'),
-  "oiiint" => CommandKind::SingleChar('\u{2230}'),
-  "therefore" => CommandKind::SingleChar('\u{2234}'),
-  "because" => CommandKind::SingleChar('\u{2235}'),
-  "backsim" => CommandKind::SingleChar('\u{223D}'),
+  // 記号（ギリシャ文字・数学記号）は機能コマンドと分離して `symbol::SYMBOL_MAP` に置く。
 };
 
 impl Evaluator {
@@ -286,9 +180,23 @@ impl Evaluator {
   /// # Errors
   ///
   /// 未知のコマンドやコマンド実行中のエラーが発生した場合
+  ///
+  /// # 解決順序
+  ///
+  /// `COMMAND_MAP`（機能コマンド）を引いた後 miss なら [`SYMBOL_MAP`]（記号）を引く。
+  /// 機能コマンド名が記号名に優先する（両マップにキー重複はテストで排除済み）。
+  /// どちらにも無ければ未知コマンドとしてエラーにする。
   pub(crate) fn evaluate_command(&mut self, view: &CommandView) -> Result<CommandResult, EvalError> {
-    let command_kind = COMMAND_MAP.get(view.name()).copied().unwrap_or(CommandKind::Undefined);
-    return command_kind.execute(view, self);
+    if let Some(command_kind) = COMMAND_MAP.get(view.name()).copied() {
+      return command_kind.execute(view, self);
+    }
+    if let Some(symbol) = SYMBOL_MAP.get(view.name()) {
+      return single_char(view, symbol.ch).map(CommandResult::Inline);
+    }
+    return Err(EvalError::UnknownCommand {
+      name: view.name().to_string(),
+      span: view.span().into(),
+    });
   }
 }
 
@@ -307,7 +215,7 @@ mod tests {
 
   #[test]
   fn single_char_rejects_unknown_opt_arg_key() {
-    // Arrange — `\alpha` は SingleChar コマンドで任意引数を受け付けない
+    // Arrange — `\alpha` は記号コマンドで任意引数を受け付けない
     let arena = Bump::new();
     let source = r"\alpha[k=v]";
     let cst = parse(source, &arena).unwrap();

--- a/crates/parser/src/evaluator/command/symbol.rs
+++ b/crates/parser/src/evaluator/command/symbol.rs
@@ -1,0 +1,404 @@
+//! 数式記号テーブル
+//!
+//! 引数なしで単一の Unicode 文字を出力する記号コマンド（ギリシャ文字・数学記号）を
+//! [`SYMBOL_MAP`] に集約する。各記号は出力文字 [`MathSymbol::ch`] と
+//! 数式クラス [`MathSymbol::class`] を持つ。
+//!
+//! ## 機能コマンドとの分離
+//!
+//! 制御・書体・色・見出し・参照・リンクといった**機能コマンド**は
+//! [`crate::evaluator::command::COMMAND_MAP`] に置き、本モジュールには
+//! **記号**だけを置く。コマンド解決は `COMMAND_MAP` を引いた後 miss なら
+//! `SYMBOL_MAP` を引く（機能コマンド名が記号名に優先する）。両マップにキー重複が
+//! ないことはテスト（`no_key_collision_between_command_and_symbol_maps`）で保証する。
+//!
+//! ## 数式クラスの位置づけ
+//!
+//! 各記号の [`MathClass`] は上流 `unicode-math-table.tex` の `\mathord` / `\mathbin` 等から
+//! 取得して記録するのみで、**本モジュールではスペーシングを実装しない**
+//! （`MathNode::Symbol` は `char` のまま）。クラスを今データに持たせておくことで、
+//! 将来の数式スペーシング実装が記号表を作り直さずに消費できる。
+//!
+//! ## 命名規則（構文設計原則 B・分かりやすさ第一）
+//!
+//! コマンド名は unicode-math の csname に一致させず、慣用の短縮形を優先して
+//! Seiran 独自に決める（`\leq` `\subseteq` `\rightarrow`）。冗長で長すぎる名前は避ける。
+
+use phf::phf_map;
+use types::MathClass;
+
+/// 記号コマンドが出力する単一文字とその数式クラス
+///
+/// [`SYMBOL_MAP`] の値として使い、記号の Unicode 文字（[`ch`](Self::ch)）と
+/// 数式クラス（[`class`](Self::class)）を対にして保持する。
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct MathSymbol {
+  /// 出力する Unicode 文字
+  pub(crate) ch: char,
+  /// 数式クラス（スペーシング用に記録、現状は未消費）
+  ///
+  /// 本 issue（#26）ではスペーシングを実装しないため、クラスはテーブルに記録するだけで
+  /// 本体コードからは読まれない（テストでは検証する）。将来の数式スペーシング実装
+  /// （#83 配下）がこのフィールドを消費する想定のため、`dead_code` を意図的に許容する。
+  #[allow(dead_code)]
+  pub(crate) class: MathClass,
+}
+
+impl MathSymbol {
+  /// 記号エントリを生成する（[`SYMBOL_MAP`] 初期化用の const コンストラクタ）
+  const fn new(ch: char, class: MathClass) -> Self { return Self { ch, class }; }
+}
+
+/// 記号コマンド名 → [`MathSymbol`] のパーフェクトハッシュマップ
+///
+/// ギリシャ文字と数学記号を数式クラス付きで集約する。記号の追加は本マップだけを
+/// 編集すれば、本文・数式の両文脈（`Evaluator::evaluate_command` /
+/// `extract_inline_nodes` / `resolve_symbol_command`）に反映される。
+pub(crate) static SYMBOL_MAP: phf::Map<&'static str, MathSymbol> = phf_map! {
+  // ───────────────────────────── ギリシャ文字（大文字, Ord）─────────────────────────────
+  "Alpha" => MathSymbol::new('\u{0391}', MathClass::Ord),
+  "Beta" => MathSymbol::new('\u{0392}', MathClass::Ord),
+  "Gamma" => MathSymbol::new('\u{0393}', MathClass::Ord),
+  "Delta" => MathSymbol::new('\u{0394}', MathClass::Ord),
+  "Epsilon" => MathSymbol::new('\u{0395}', MathClass::Ord),
+  "Zeta" => MathSymbol::new('\u{0396}', MathClass::Ord),
+  "Eta" => MathSymbol::new('\u{0397}', MathClass::Ord),
+  "Theta" => MathSymbol::new('\u{0398}', MathClass::Ord),
+  "Iota" => MathSymbol::new('\u{0399}', MathClass::Ord),
+  "Kappa" => MathSymbol::new('\u{039A}', MathClass::Ord),
+  "Lambda" => MathSymbol::new('\u{039B}', MathClass::Ord),
+  "Mu" => MathSymbol::new('\u{039C}', MathClass::Ord),
+  "Nu" => MathSymbol::new('\u{039D}', MathClass::Ord),
+  "Xi" => MathSymbol::new('\u{039E}', MathClass::Ord),
+  "Omicron" => MathSymbol::new('\u{039F}', MathClass::Ord),
+  "Pi" => MathSymbol::new('\u{03A0}', MathClass::Ord),
+  "Rho" => MathSymbol::new('\u{03A1}', MathClass::Ord),
+  "Sigma" => MathSymbol::new('\u{03A3}', MathClass::Ord),
+  "Tau" => MathSymbol::new('\u{03A4}', MathClass::Ord),
+  "Upsilon" => MathSymbol::new('\u{03A5}', MathClass::Ord),
+  "Phi" => MathSymbol::new('\u{03A6}', MathClass::Ord),
+  "Chi" => MathSymbol::new('\u{03A7}', MathClass::Ord),
+  "Psi" => MathSymbol::new('\u{03A8}', MathClass::Ord),
+  "Omega" => MathSymbol::new('\u{03A9}', MathClass::Ord),
+
+  // ───────────────────────────── ギリシャ文字（小文字, Ord）─────────────────────────────
+  "alpha" => MathSymbol::new('\u{03B1}', MathClass::Ord),
+  "beta" => MathSymbol::new('\u{03B2}', MathClass::Ord),
+  "gamma" => MathSymbol::new('\u{03B3}', MathClass::Ord),
+  "delta" => MathSymbol::new('\u{03B4}', MathClass::Ord),
+  "epsilon" => MathSymbol::new('\u{03B5}', MathClass::Ord),
+  "varepsilon" => MathSymbol::new('\u{03F5}', MathClass::Ord),
+  "zeta" => MathSymbol::new('\u{03B6}', MathClass::Ord),
+  "eta" => MathSymbol::new('\u{03B7}', MathClass::Ord),
+  "theta" => MathSymbol::new('\u{03B8}', MathClass::Ord),
+  "vartheta" => MathSymbol::new('\u{03D1}', MathClass::Ord),
+  "iota" => MathSymbol::new('\u{03B9}', MathClass::Ord),
+  "kappa" => MathSymbol::new('\u{03BA}', MathClass::Ord),
+  "varkappa" => MathSymbol::new('\u{03F0}', MathClass::Ord),
+  "lambda" => MathSymbol::new('\u{03BB}', MathClass::Ord),
+  "mu" => MathSymbol::new('\u{03BC}', MathClass::Ord),
+  "nu" => MathSymbol::new('\u{03BD}', MathClass::Ord),
+  "xi" => MathSymbol::new('\u{03BE}', MathClass::Ord),
+  "omicron" => MathSymbol::new('\u{03BF}', MathClass::Ord),
+  "pi" => MathSymbol::new('\u{03C0}', MathClass::Ord),
+  "varpi" => MathSymbol::new('\u{03D6}', MathClass::Ord),
+  "rho" => MathSymbol::new('\u{03C1}', MathClass::Ord),
+  "varrho" => MathSymbol::new('\u{03F1}', MathClass::Ord),
+  "sigma" => MathSymbol::new('\u{03C3}', MathClass::Ord),
+  "varsigma" => MathSymbol::new('\u{03C2}', MathClass::Ord),
+  "tau" => MathSymbol::new('\u{03C4}', MathClass::Ord),
+  "upsilon" => MathSymbol::new('\u{03C5}', MathClass::Ord),
+  "phi" => MathSymbol::new('\u{03C6}', MathClass::Ord),
+  "varphi" => MathSymbol::new('\u{03D5}', MathClass::Ord),
+  "chi" => MathSymbol::new('\u{03C7}', MathClass::Ord),
+  "psi" => MathSymbol::new('\u{03C8}', MathClass::Ord),
+  "omega" => MathSymbol::new('\u{03C9}', MathClass::Ord),
+
+  // ───────────────────────────── 名前付き記号・定数（Ord）─────────────────────────────
+  "forall" => MathSymbol::new('\u{2200}', MathClass::Ord),
+  "complement" => MathSymbol::new('\u{2201}', MathClass::Ord),
+  "partial" => MathSymbol::new('\u{2202}', MathClass::Ord),
+  "exists" => MathSymbol::new('\u{2203}', MathClass::Ord),
+  "notexists" => MathSymbol::new('\u{2204}', MathClass::Ord),
+  "emptyset" => MathSymbol::new('\u{2205}', MathClass::Ord),
+  "increment" => MathSymbol::new('\u{2206}', MathClass::Ord),
+  "nabla" => MathSymbol::new('\u{2207}', MathClass::Ord),
+  "qed" => MathSymbol::new('\u{220E}', MathClass::Ord),
+  "surd" => MathSymbol::new('\u{221A}', MathClass::Ord),
+  "infty" => MathSymbol::new('\u{221E}', MathClass::Ord),
+  "rightangle" => MathSymbol::new('\u{221F}', MathClass::Ord),
+  "angle" => MathSymbol::new('\u{2220}', MathClass::Ord),
+  "measuredangle" => MathSymbol::new('\u{2221}', MathClass::Ord),
+  "sphericalangle" => MathSymbol::new('\u{2222}', MathClass::Ord),
+  "therefore" => MathSymbol::new('\u{2234}', MathClass::Ord),
+  "because" => MathSymbol::new('\u{2235}', MathClass::Ord),
+  "neg" => MathSymbol::new('\u{00AC}', MathClass::Ord),
+  "hbar" => MathSymbol::new('\u{210F}', MathClass::Ord),
+  "ell" => MathSymbol::new('\u{2113}', MathClass::Ord),
+  "wp" => MathSymbol::new('\u{2118}', MathClass::Ord),
+  "Re" => MathSymbol::new('\u{211C}', MathClass::Ord),
+  "Im" => MathSymbol::new('\u{2111}', MathClass::Ord),
+  "aleph" => MathSymbol::new('\u{2135}', MathClass::Ord),
+  "beth" => MathSymbol::new('\u{2136}', MathClass::Ord),
+  "gimel" => MathSymbol::new('\u{2137}', MathClass::Ord),
+  "daleth" => MathSymbol::new('\u{2138}', MathClass::Ord),
+  "mho" => MathSymbol::new('\u{2127}', MathClass::Ord),
+  "Finv" => MathSymbol::new('\u{2132}', MathClass::Ord),
+  "Game" => MathSymbol::new('\u{2141}', MathClass::Ord),
+  "eth" => MathSymbol::new('\u{00F0}', MathClass::Ord),
+  "prime" => MathSymbol::new('\u{2032}', MathClass::Ord),
+  "backprime" => MathSymbol::new('\u{2035}', MathClass::Ord),
+  "top" => MathSymbol::new('\u{22A4}', MathClass::Ord),
+  "bot" => MathSymbol::new('\u{22A5}', MathClass::Ord),
+  "triangle" => MathSymbol::new('\u{25B3}', MathClass::Ord),
+  "blacktriangle" => MathSymbol::new('\u{25B2}', MathClass::Ord),
+  "blacktriangledown" => MathSymbol::new('\u{25BC}', MathClass::Ord),
+  "square" => MathSymbol::new('\u{25A1}', MathClass::Ord),
+  "blacksquare" => MathSymbol::new('\u{25A0}', MathClass::Ord),
+  "lozenge" => MathSymbol::new('\u{25CA}', MathClass::Ord),
+  "blacklozenge" => MathSymbol::new('\u{29EB}', MathClass::Ord),
+  "bigstar" => MathSymbol::new('\u{2605}', MathClass::Ord),
+  "diagup" => MathSymbol::new('\u{2571}', MathClass::Ord),
+  "diagdown" => MathSymbol::new('\u{2572}', MathClass::Ord),
+  "sharp" => MathSymbol::new('\u{266F}', MathClass::Ord),
+  "flat" => MathSymbol::new('\u{266D}', MathClass::Ord),
+  "natural" => MathSymbol::new('\u{266E}', MathClass::Ord),
+  "clubsuit" => MathSymbol::new('\u{2663}', MathClass::Ord),
+  "diamondsuit" => MathSymbol::new('\u{2662}', MathClass::Ord),
+  "heartsuit" => MathSymbol::new('\u{2661}', MathClass::Ord),
+  "spadesuit" => MathSymbol::new('\u{2660}', MathClass::Ord),
+  "checkmark" => MathSymbol::new('\u{2713}', MathClass::Ord),
+  "maltese" => MathSymbol::new('\u{2720}', MathClass::Ord),
+  "circledR" => MathSymbol::new('\u{00AE}', MathClass::Ord),
+  "circledS" => MathSymbol::new('\u{24C8}', MathClass::Ord),
+  "ldots" => MathSymbol::new('\u{2026}', MathClass::Ord),
+  "cdots" => MathSymbol::new('\u{22EF}', MathClass::Ord),
+  "vdots" => MathSymbol::new('\u{22EE}', MathClass::Ord),
+  "ddots" => MathSymbol::new('\u{22F1}', MathClass::Ord),
+
+  // ───────────────────────────── 大型演算子（Op）─────────────────────────────
+  "prod" => MathSymbol::new('\u{220F}', MathClass::Op),
+  "coprod" => MathSymbol::new('\u{2210}', MathClass::Op),
+  "sum" => MathSymbol::new('\u{2211}', MathClass::Op),
+  "int" => MathSymbol::new('\u{222B}', MathClass::Op),
+  "iint" => MathSymbol::new('\u{222C}', MathClass::Op),
+  "iiint" => MathSymbol::new('\u{222D}', MathClass::Op),
+  "oint" => MathSymbol::new('\u{222E}', MathClass::Op),
+  "oiint" => MathSymbol::new('\u{222F}', MathClass::Op),
+  "oiiint" => MathSymbol::new('\u{2230}', MathClass::Op),
+  "bigcap" => MathSymbol::new('\u{22C2}', MathClass::Op),
+  "bigcup" => MathSymbol::new('\u{22C3}', MathClass::Op),
+  "bigsqcup" => MathSymbol::new('\u{2A06}', MathClass::Op),
+  "bigvee" => MathSymbol::new('\u{22C1}', MathClass::Op),
+  "bigwedge" => MathSymbol::new('\u{22C0}', MathClass::Op),
+  "bigodot" => MathSymbol::new('\u{2A00}', MathClass::Op),
+  "bigoplus" => MathSymbol::new('\u{2A01}', MathClass::Op),
+  "bigotimes" => MathSymbol::new('\u{2A02}', MathClass::Op),
+  "biguplus" => MathSymbol::new('\u{2A04}', MathClass::Op),
+
+  // ───────────────────────────── 二項演算子（Bin）─────────────────────────────
+  "minus" => MathSymbol::new('\u{2212}', MathClass::Bin),
+  "mp" => MathSymbol::new('\u{2213}', MathClass::Bin),
+  "pm" => MathSymbol::new('\u{00B1}', MathClass::Bin),
+  "dotplus" => MathSymbol::new('\u{2214}', MathClass::Bin),
+  "slash" => MathSymbol::new('\u{2215}', MathClass::Bin),
+  "times" => MathSymbol::new('\u{00D7}', MathClass::Bin),
+  "div" => MathSymbol::new('\u{00F7}', MathClass::Bin),
+  "cdot" => MathSymbol::new('\u{22C5}', MathClass::Bin),
+  "ast" => MathSymbol::new('\u{2217}', MathClass::Bin),
+  "star" => MathSymbol::new('\u{22C6}', MathClass::Bin),
+  "circ" => MathSymbol::new('\u{2218}', MathClass::Bin),
+  "bullet" => MathSymbol::new('\u{2219}', MathClass::Bin),
+  "diamond" => MathSymbol::new('\u{22C4}', MathClass::Bin),
+  "setminus" => MathSymbol::new('\u{2216}', MathClass::Bin),
+  "land" => MathSymbol::new('\u{2227}', MathClass::Bin),
+  "lor" => MathSymbol::new('\u{2228}', MathClass::Bin),
+  "wedge" => MathSymbol::new('\u{2227}', MathClass::Bin),
+  "vee" => MathSymbol::new('\u{2228}', MathClass::Bin),
+  "cap" => MathSymbol::new('\u{2229}', MathClass::Bin),
+  "cup" => MathSymbol::new('\u{222A}', MathClass::Bin),
+  "sqcap" => MathSymbol::new('\u{2293}', MathClass::Bin),
+  "sqcup" => MathSymbol::new('\u{2294}', MathClass::Bin),
+  "uplus" => MathSymbol::new('\u{228E}', MathClass::Bin),
+  "amalg" => MathSymbol::new('\u{2A3F}', MathClass::Bin),
+  "wr" => MathSymbol::new('\u{2240}', MathClass::Bin),
+  "oplus" => MathSymbol::new('\u{2295}', MathClass::Bin),
+  "ominus" => MathSymbol::new('\u{2296}', MathClass::Bin),
+  "otimes" => MathSymbol::new('\u{2297}', MathClass::Bin),
+  "oslash" => MathSymbol::new('\u{2298}', MathClass::Bin),
+  "odot" => MathSymbol::new('\u{2299}', MathClass::Bin),
+  "boxplus" => MathSymbol::new('\u{229E}', MathClass::Bin),
+  "boxminus" => MathSymbol::new('\u{229F}', MathClass::Bin),
+  "boxtimes" => MathSymbol::new('\u{22A0}', MathClass::Bin),
+  "boxdot" => MathSymbol::new('\u{22A1}', MathClass::Bin),
+  "triangleleft" => MathSymbol::new('\u{25C1}', MathClass::Bin),
+  "triangleright" => MathSymbol::new('\u{25B7}', MathClass::Bin),
+  "bigtriangleup" => MathSymbol::new('\u{25B3}', MathClass::Bin),
+  "bigtriangledown" => MathSymbol::new('\u{25BD}', MathClass::Bin),
+  "dagger" => MathSymbol::new('\u{2020}', MathClass::Bin),
+  "ddagger" => MathSymbol::new('\u{2021}', MathClass::Bin),
+  "ltimes" => MathSymbol::new('\u{22C9}', MathClass::Bin),
+  "rtimes" => MathSymbol::new('\u{22CA}', MathClass::Bin),
+  "barwedge" => MathSymbol::new('\u{22BC}', MathClass::Bin),
+  "veebar" => MathSymbol::new('\u{22BB}', MathClass::Bin),
+  "intercal" => MathSymbol::new('\u{22BA}', MathClass::Bin),
+  "Cap" => MathSymbol::new('\u{22D2}', MathClass::Bin),
+  "Cup" => MathSymbol::new('\u{22D3}', MathClass::Bin),
+
+  // ───────────────────────────── 関係子（Rel）─────────────────────────────
+  "in" => MathSymbol::new('\u{2208}', MathClass::Rel),
+  "notin" => MathSymbol::new('\u{2209}', MathClass::Rel),
+  "ni" => MathSymbol::new('\u{220B}', MathClass::Rel),
+  "notni" => MathSymbol::new('\u{220C}', MathClass::Rel),
+  "propto" => MathSymbol::new('\u{221D}', MathClass::Rel),
+  "mid" => MathSymbol::new('\u{2223}', MathClass::Rel),
+  "nmid" => MathSymbol::new('\u{2224}', MathClass::Rel),
+  "parallel" => MathSymbol::new('\u{2225}', MathClass::Rel),
+  "notparallel" => MathSymbol::new('\u{2226}', MathClass::Rel),
+  "backsim" => MathSymbol::new('\u{223D}', MathClass::Rel),
+  "sim" => MathSymbol::new('\u{223C}', MathClass::Rel),
+  "nsim" => MathSymbol::new('\u{2241}', MathClass::Rel),
+  "simeq" => MathSymbol::new('\u{2243}', MathClass::Rel),
+  "approx" => MathSymbol::new('\u{2248}', MathClass::Rel),
+  "approxeq" => MathSymbol::new('\u{224A}', MathClass::Rel),
+  "asymp" => MathSymbol::new('\u{224D}', MathClass::Rel),
+  "cong" => MathSymbol::new('\u{2245}', MathClass::Rel),
+  "ncong" => MathSymbol::new('\u{2247}', MathClass::Rel),
+  "doteq" => MathSymbol::new('\u{2250}', MathClass::Rel),
+  "triangleq" => MathSymbol::new('\u{225C}', MathClass::Rel),
+  "neq" => MathSymbol::new('\u{2260}', MathClass::Rel),
+  "equiv" => MathSymbol::new('\u{2261}', MathClass::Rel),
+  "leq" => MathSymbol::new('\u{2264}', MathClass::Rel),
+  "geq" => MathSymbol::new('\u{2265}', MathClass::Rel),
+  "ll" => MathSymbol::new('\u{226A}', MathClass::Rel),
+  "gg" => MathSymbol::new('\u{226B}', MathClass::Rel),
+  "nless" => MathSymbol::new('\u{226E}', MathClass::Rel),
+  "ngtr" => MathSymbol::new('\u{226F}', MathClass::Rel),
+  "nleq" => MathSymbol::new('\u{2270}', MathClass::Rel),
+  "ngeq" => MathSymbol::new('\u{2271}', MathClass::Rel),
+  "lesssim" => MathSymbol::new('\u{2272}', MathClass::Rel),
+  "gtrsim" => MathSymbol::new('\u{2273}', MathClass::Rel),
+  "lessgtr" => MathSymbol::new('\u{2276}', MathClass::Rel),
+  "gtrless" => MathSymbol::new('\u{2277}', MathClass::Rel),
+  "prec" => MathSymbol::new('\u{227A}', MathClass::Rel),
+  "succ" => MathSymbol::new('\u{227B}', MathClass::Rel),
+  "preceq" => MathSymbol::new('\u{227C}', MathClass::Rel),
+  "succeq" => MathSymbol::new('\u{227D}', MathClass::Rel),
+  "nprec" => MathSymbol::new('\u{2280}', MathClass::Rel),
+  "nsucc" => MathSymbol::new('\u{2281}', MathClass::Rel),
+  "subset" => MathSymbol::new('\u{2282}', MathClass::Rel),
+  "supset" => MathSymbol::new('\u{2283}', MathClass::Rel),
+  "subseteq" => MathSymbol::new('\u{2286}', MathClass::Rel),
+  "supseteq" => MathSymbol::new('\u{2287}', MathClass::Rel),
+  "nsubseteq" => MathSymbol::new('\u{2288}', MathClass::Rel),
+  "nsupseteq" => MathSymbol::new('\u{2289}', MathClass::Rel),
+  "subsetneq" => MathSymbol::new('\u{228A}', MathClass::Rel),
+  "supsetneq" => MathSymbol::new('\u{228B}', MathClass::Rel),
+  "sqsubset" => MathSymbol::new('\u{228F}', MathClass::Rel),
+  "sqsupset" => MathSymbol::new('\u{2290}', MathClass::Rel),
+  "sqsubseteq" => MathSymbol::new('\u{2291}', MathClass::Rel),
+  "sqsupseteq" => MathSymbol::new('\u{2292}', MathClass::Rel),
+  "vdash" => MathSymbol::new('\u{22A2}', MathClass::Rel),
+  "dashv" => MathSymbol::new('\u{22A3}', MathClass::Rel),
+  "perp" => MathSymbol::new('\u{22A5}', MathClass::Rel),
+  "models" => MathSymbol::new('\u{22A8}', MathClass::Rel),
+  "nvdash" => MathSymbol::new('\u{22AC}', MathClass::Rel),
+
+  // ───────────────────────────── 矢印（Rel）─────────────────────────────
+  "leftarrow" => MathSymbol::new('\u{2190}', MathClass::Rel),
+  "uparrow" => MathSymbol::new('\u{2191}', MathClass::Rel),
+  "rightarrow" => MathSymbol::new('\u{2192}', MathClass::Rel),
+  "downarrow" => MathSymbol::new('\u{2193}', MathClass::Rel),
+  "leftrightarrow" => MathSymbol::new('\u{2194}', MathClass::Rel),
+  "updownarrow" => MathSymbol::new('\u{2195}', MathClass::Rel),
+  "nwarrow" => MathSymbol::new('\u{2196}', MathClass::Rel),
+  "nearrow" => MathSymbol::new('\u{2197}', MathClass::Rel),
+  "searrow" => MathSymbol::new('\u{2198}', MathClass::Rel),
+  "swarrow" => MathSymbol::new('\u{2199}', MathClass::Rel),
+  "nleftarrow" => MathSymbol::new('\u{219A}', MathClass::Rel),
+  "nrightarrow" => MathSymbol::new('\u{219B}', MathClass::Rel),
+  "twoheadleftarrow" => MathSymbol::new('\u{219E}', MathClass::Rel),
+  "twoheadrightarrow" => MathSymbol::new('\u{21A0}', MathClass::Rel),
+  "hookleftarrow" => MathSymbol::new('\u{21A9}', MathClass::Rel),
+  "hookrightarrow" => MathSymbol::new('\u{21AA}', MathClass::Rel),
+  "mapsto" => MathSymbol::new('\u{21A6}', MathClass::Rel),
+  "nleftrightarrow" => MathSymbol::new('\u{21AE}', MathClass::Rel),
+  "leftharpoonup" => MathSymbol::new('\u{21BC}', MathClass::Rel),
+  "leftharpoondown" => MathSymbol::new('\u{21BD}', MathClass::Rel),
+  "rightharpoonup" => MathSymbol::new('\u{21C0}', MathClass::Rel),
+  "rightharpoondown" => MathSymbol::new('\u{21C1}', MathClass::Rel),
+  "rightleftarrows" => MathSymbol::new('\u{21C4}', MathClass::Rel),
+  "leftrightarrows" => MathSymbol::new('\u{21C6}', MathClass::Rel),
+  "leftleftarrows" => MathSymbol::new('\u{21C7}', MathClass::Rel),
+  "upuparrows" => MathSymbol::new('\u{21C8}', MathClass::Rel),
+  "rightrightarrows" => MathSymbol::new('\u{21C9}', MathClass::Rel),
+  "downdownarrows" => MathSymbol::new('\u{21CA}', MathClass::Rel),
+  "rightleftharpoons" => MathSymbol::new('\u{21CC}', MathClass::Rel),
+  "curvearrowleft" => MathSymbol::new('\u{21B6}', MathClass::Rel),
+  "curvearrowright" => MathSymbol::new('\u{21B7}', MathClass::Rel),
+  "circlearrowleft" => MathSymbol::new('\u{21BA}', MathClass::Rel),
+  "circlearrowright" => MathSymbol::new('\u{21BB}', MathClass::Rel),
+  "Leftarrow" => MathSymbol::new('\u{21D0}', MathClass::Rel),
+  "Uparrow" => MathSymbol::new('\u{21D1}', MathClass::Rel),
+  "Rightarrow" => MathSymbol::new('\u{21D2}', MathClass::Rel),
+  "Downarrow" => MathSymbol::new('\u{21D3}', MathClass::Rel),
+  "Leftrightarrow" => MathSymbol::new('\u{21D4}', MathClass::Rel),
+  "Updownarrow" => MathSymbol::new('\u{21D5}', MathClass::Rel),
+  "nLeftarrow" => MathSymbol::new('\u{21CD}', MathClass::Rel),
+  "nLeftrightarrow" => MathSymbol::new('\u{21CE}', MathClass::Rel),
+  "nRightarrow" => MathSymbol::new('\u{21CF}', MathClass::Rel),
+  "longleftarrow" => MathSymbol::new('\u{27F5}', MathClass::Rel),
+  "longrightarrow" => MathSymbol::new('\u{27F6}', MathClass::Rel),
+  "longleftrightarrow" => MathSymbol::new('\u{27F7}', MathClass::Rel),
+  "Longleftarrow" => MathSymbol::new('\u{27F8}', MathClass::Rel),
+  "Longrightarrow" => MathSymbol::new('\u{27F9}', MathClass::Rel),
+  "Longleftrightarrow" => MathSymbol::new('\u{27FA}', MathClass::Rel),
+  "longmapsto" => MathSymbol::new('\u{27FC}', MathClass::Rel),
+
+  // ───────────────────────────── 開き / 閉じ括弧（Open / Close）─────────────────────────────
+  "langle" => MathSymbol::new('\u{27E8}', MathClass::Open),
+  "rangle" => MathSymbol::new('\u{27E9}', MathClass::Close),
+  "lceil" => MathSymbol::new('\u{2308}', MathClass::Open),
+  "rceil" => MathSymbol::new('\u{2309}', MathClass::Close),
+  "lfloor" => MathSymbol::new('\u{230A}', MathClass::Open),
+  "rfloor" => MathSymbol::new('\u{230B}', MathClass::Close),
+  "vert" => MathSymbol::new('\u{007C}', MathClass::Ord),
+  "Vert" => MathSymbol::new('\u{2016}', MathClass::Ord),
+};
+
+#[cfg(test)]
+mod tests {
+  use super::SYMBOL_MAP;
+  use crate::evaluator::command::COMMAND_MAP;
+
+  #[test]
+  fn representative_symbols_have_expected_class() {
+    // Arrange & Act & Assert — 代表記号のクラスが各カテゴリで正しいこと
+    use types::MathClass;
+    assert_eq!(SYMBOL_MAP.get("alpha").map(|s| s.class), Some(MathClass::Ord));
+    assert_eq!(SYMBOL_MAP.get("leq").map(|s| s.class), Some(MathClass::Rel));
+    assert_eq!(SYMBOL_MAP.get("times").map(|s| s.class), Some(MathClass::Bin));
+    assert_eq!(SYMBOL_MAP.get("sum").map(|s| s.class), Some(MathClass::Op));
+    assert_eq!(SYMBOL_MAP.get("rightarrow").map(|s| s.class), Some(MathClass::Rel));
+    assert_eq!(SYMBOL_MAP.get("langle").map(|s| s.class), Some(MathClass::Open));
+    assert_eq!(SYMBOL_MAP.get("rangle").map(|s| s.class), Some(MathClass::Close));
+  }
+
+  #[test]
+  fn representative_symbols_map_to_expected_char() {
+    // Arrange & Act & Assert — 移設した既存記号・新規 amssymb 記号が正しい文字に解決される
+    assert_eq!(SYMBOL_MAP.get("alpha").map(|s| s.ch), Some('\u{03B1}'));
+    assert_eq!(SYMBOL_MAP.get("leq").map(|s| s.ch), Some('\u{2264}'));
+    assert_eq!(SYMBOL_MAP.get("geq").map(|s| s.ch), Some('\u{2265}'));
+    assert_eq!(SYMBOL_MAP.get("subseteq").map(|s| s.ch), Some('\u{2286}'));
+    assert_eq!(SYMBOL_MAP.get("Rightarrow").map(|s| s.ch), Some('\u{21D2}'));
+  }
+
+  #[test]
+  fn no_key_collision_between_command_and_symbol_maps() {
+    // Arrange & Act & Assert — 機能コマンドと記号のキーは重複してはならない（解決順序の衝突ガード）
+    for key in SYMBOL_MAP.keys() {
+      assert!(!COMMAND_MAP.contains_key(key), "COMMAND_MAP と SYMBOL_MAP にキーが重複しています: {key}");
+    }
+  }
+}

--- a/crates/parser/src/evaluator/inline.rs
+++ b/crates/parser/src/evaluator/inline.rs
@@ -25,6 +25,7 @@ use crate::evaluator::{
     link::{href_command, url_command},
     ref_::ref_command,
     single_char,
+    symbol::SYMBOL_MAP,
   },
   math,
 };
@@ -104,9 +105,6 @@ pub(crate) fn extract_inline_nodes_from_elements(
               // `\color[color=#rrggbb]{...}` も書体指定と同じくインライン文脈で展開する
               inlines.extend(colored_text(&view)?);
             },
-            Some(CommandKind::SingleChar(ch)) => {
-              inlines.extend(single_char(&view, ch)?);
-            },
             Some(CommandKind::Ref) => {
               // 見出しタイトル・キャプション内に出現する `\ref{label}` も
               // pass1 ではスタブを生成し pass2 で解決する
@@ -129,11 +127,16 @@ pub(crate) fn extract_inline_nodes_from_elements(
                 span: view.span().into(),
               });
             },
-            Some(CommandKind::Undefined) | None => {
-              return Err(EvalError::UnknownCommand {
-                name: view.name().to_string(),
-                span: view.span().into(),
-              });
+            None => {
+              // 機能コマンドに無ければ記号テーブルを引く（COMMAND_MAP→miss→SYMBOL_MAP）
+              if let Some(symbol) = SYMBOL_MAP.get(view.name()) {
+                inlines.extend(single_char(&view, symbol.ch)?);
+              } else {
+                return Err(EvalError::UnknownCommand {
+                  name: view.name().to_string(),
+                  span: view.span().into(),
+                });
+              }
             },
           }
         },
@@ -164,16 +167,15 @@ pub(crate) fn extract_inline_nodes_from_elements(
 /// コマンド名からシンボル文字を解決する
 ///
 /// ギリシャ文字・数学記号等の引数なしコマンドを対応する Unicode 文字に変換します。
-/// 未知のコマンド名、または `SingleChar` 以外のコマンド種別の場合は `None` を返します。
+/// 記号テーブル [`SYMBOL_MAP`] に無いコマンド名（機能コマンドや未知の名前）の場合は
+/// `None` を返します。
 ///
-/// 解決の単一ソースは [`COMMAND_MAP`]。コマンド追加はそちらだけを編集すれば、
-/// 本関数および `Evaluator::evaluate_command` の双方に反映される。
+/// 解決の単一ソースは [`SYMBOL_MAP`]。記号追加はそちらだけを編集すれば、
+/// 本関数（数式文脈）・`Evaluator::evaluate_command`・`extract_inline_nodes`（本文文脈）の
+/// すべてに反映される。
 #[must_use]
 pub(crate) fn resolve_symbol_command(name: &str) -> Option<char> {
-  if let Some(CommandKind::SingleChar(ch)) = COMMAND_MAP.get(name).copied() {
-    return Some(ch);
-  }
-  return None;
+  return SYMBOL_MAP.get(name).map(|symbol| symbol.ch);
 }
 
 #[cfg(test)]
@@ -220,6 +222,41 @@ mod tests {
     let inlines = extract_inline_nodes(source, arg).unwrap();
     assert_eq!(inlines.len(), 1);
     assert!(matches!(&inlines[0], InlineNode::Symbol('α')));
+  }
+
+  #[test]
+  fn extract_inline_nodes_resolves_amssymb_symbol() {
+    // Arrange — `\leq` は SYMBOL_MAP に移設・追加した amssymb 記号。本文文脈でも解決される
+    let arena = Bump::new();
+    let source = "\\section{\\leq}";
+    let cst = parse(source, &arena).unwrap();
+    let section_node = cst.child_nodes().next().unwrap();
+    let view = CommandView::new(section_node, source);
+    let arg = view.first_arg().unwrap();
+
+    // Act
+    let inlines = extract_inline_nodes(source, arg).unwrap();
+
+    // Assert
+    assert_eq!(inlines.len(), 1);
+    assert!(matches!(&inlines[0], InlineNode::Symbol('≤')));
+  }
+
+  #[test]
+  fn extract_inline_nodes_rejects_unknown_command() {
+    // Arrange — COMMAND_MAP にも SYMBOL_MAP にも無い名前は未知コマンドエラー
+    let arena = Bump::new();
+    let source = "\\section{\\nonexistent}";
+    let cst = parse(source, &arena).unwrap();
+    let section_node = cst.child_nodes().next().unwrap();
+    let view = CommandView::new(section_node, source);
+    let arg = view.first_arg().unwrap();
+
+    // Act
+    let result = extract_inline_nodes(source, arg);
+
+    // Assert
+    assert!(matches!(result, Err(EvalError::UnknownCommand { ref name, .. }) if name == "nonexistent"));
   }
 
   #[test]

--- a/crates/parser/tests/evaluate.rs
+++ b/crates/parser/tests/evaluate.rs
@@ -308,6 +308,43 @@ fn evaluate_inline_command_stays_in_paragraph() {
 }
 
 #[test]
+fn evaluate_amssymb_symbol_in_body_resolves_to_symbol() {
+  // Arrange & Act — `\geq` は SYMBOL_MAP に追加した amssymb 記号。本文文脈で解決される
+  let result = evaluate_source(r"a \geq b");
+
+  // Assert
+  assert_eq!(result.len(), 1);
+  match &result[0] {
+    DocNode::Paragraph(inlines) => {
+      assert!(
+        inlines.iter().any(|n| matches!(n, InlineNode::Symbol('≥'))),
+        "≥ の Symbol ノードが含まれるはず: {inlines:?}"
+      );
+    },
+    _ => panic!("Paragraph が期待されます"),
+  }
+}
+
+#[test]
+fn evaluate_amssymb_symbol_in_math_resolves_to_symbol() {
+  // Arrange & Act — 数式文脈でも SYMBOL_MAP 経由で記号が解決される
+  let result = evaluate_source(r"$a \leq b$");
+
+  // Assert
+  assert_eq!(result.len(), 1);
+  let DocNode::Paragraph(inlines) = &result[0] else {
+    panic!("Paragraph が期待されます");
+  };
+  let InlineNode::InlineMath(math) = &inlines[0] else {
+    panic!("InlineMath が期待されます");
+  };
+  assert!(
+    math.iter().any(|n| matches!(n, MathNode::Symbol('≤'))),
+    "≤ の MathNode::Symbol が含まれるはず: {math:?}"
+  );
+}
+
+#[test]
 fn evaluate_empty_input_returns_empty() {
   let result = evaluate_source("");
   assert!(result.is_empty());

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -9,6 +9,7 @@
 //! - [`font_map`] - 全フォント種別に値を対応付ける汎用コンテナ [`FontMap`]
 //! - [`heading_level`] - 見出しのレベル [`HeadingLevel`]
 //! - [`length`] - 単位付き長さ値 [`Length`]
+//! - [`math`] - 数式環境の種別 [`MathEnvKind`] / 区切り括弧 [`MathDelimiter`] / 記号の数式クラス [`MathClass`]
 //! - [`table`] - 表の列指定 [`TableColumn`] / [`ColumnAlign`] / [`ColumnWidth`]
 //! - [`link`] - ハイパーリンク機構の到達先 [`AnchorMark`]（機構 A）とリンク行き先 [`LinkTarget`]（機構 B）
 //! - [`color`] - 8bit RGB 色 [`Color`]（背景色 / 罫線色 / テキスト色の共通表現）
@@ -60,5 +61,5 @@ pub use font_map::{FontMap, FontMapIter, FontMapIterMut};
 pub use heading_level::HeadingLevel;
 pub use length::Length;
 pub use link::{AnchorMark, LinkTarget};
-pub use math::{MathDelimiter, MathEnvKind};
+pub use math::{MathClass, MathDelimiter, MathEnvKind};
 pub use table::{ColumnAlign, ColumnWidth, TableColumn};

--- a/crates/types/src/math.rs
+++ b/crates/types/src/math.rs
@@ -1,9 +1,40 @@
-//! 数式環境の種別 [`MathEnvKind`] と区切り括弧 [`MathDelimiter`]。
+//! 数式環境の種別 [`MathEnvKind`]・区切り括弧 [`MathDelimiter`]・記号の数式クラス [`MathClass`]。
 //!
 //! ディスプレイ数式環境（`equation` / `align` / `gather` / `split` / `multiline` / `cases` / `matrix`）の
 //! 種別を表す共通型。`document`（IR）・`lowering`（`LayoutNode`）・`layout`（組版）が
 //! 共有するため、依存の基盤である本クレートに置く。`parser` が環境名から決定し、
 //! `layout` 段の列整列・区切り括弧・行採番まで透過的に伝播する。
+//!
+//! [`MathClass`] は数式記号のクラス（順序子・演算子・二項演算子・関係子・開き / 閉じ括弧・区切り）を
+//! 表す。`parser` の記号テーブルが各記号に付与し、将来の数式スペーシング実装がクラスの
+//! 組み合わせから記号間のアキを決めるためのデータ源となる（現状はクラスを記録するのみ）。
+
+/// 数式記号のクラス
+///
+/// TeX 系の数式組版では、記号同士の間隔がこのクラスの組み合わせで決まる
+/// （`a + b` の `+`（[`Bin`](MathClass::Bin)）は中アキ、`a = b` の `=`（[`Rel`](MathClass::Rel)）は太アキ）。
+/// 現状の Seiran はこのスペーシングを実装していないが、記号テーブルに
+/// クラスを記録しておくことで、将来の数式スペーシング実装が記号表を
+/// 作り直さずにクラスを消費できる。
+///
+/// クラスは上流の `unicode-math-table.tex` の `\mathord` / `\mathbin` 等から取得する。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MathClass {
+  /// 順序子（`\mathord`）— 変数・名前付き記号など（`\alpha` `\infty` `\hbar`）
+  Ord,
+  /// 大型演算子（`\mathop`）— 総和・積分など（`\sum` `\int` `\prod`）
+  Op,
+  /// 二項演算子（`\mathbin`）— 中アキを伴う演算子（`\times` `\oplus` `\cup`）
+  Bin,
+  /// 関係子（`\mathrel`）— 太アキを伴う関係・矢印（`\leq` `\subseteq` `\rightarrow`）
+  Rel,
+  /// 開き括弧（`\mathopen`）— 開き区切り（`\langle` `\lceil`）
+  Open,
+  /// 閉じ括弧（`\mathclose`）— 閉じ区切り（`\rangle` `\rceil`）
+  Close,
+  /// 区切り（`\mathpunct`）— 句読点的記号（`\colon` 等）
+  Punct,
+}
 
 /// ディスプレイ数式環境の種別
 ///


### PR DESCRIPTION
## 概要

issue #26（epic #83 の第一弾）を実装。数式記号を **amssymb 相当**まで拡充し、将来 unicode-math 相当のフルカバレッジへ素直に拡張できるよう、記号データを**専用テーブルに集約**して各記号に**数式クラス**を持たせる基盤を確立する。

Closes #26

## 変更内容

### 1. 記号テーブルを専用モジュールに分離
- `types::math` に `MathClass`（`Ord` / `Op` / `Bin` / `Rel` / `Open` / `Close` / `Punct`）を新設し、`types` lib で再エクスポート
- parser に `crates/parser/src/evaluator/command/symbol.rs` を新設し、`SYMBOL_MAP: phf::Map<&str, MathSymbol>`（`MathSymbol { ch, class }`）を定義
- 既存の `SingleChar` 記号（ギリシャ + 約 40）を `COMMAND_MAP` から `SYMBOL_MAP` へ移設し、正しいクラスを付与。移設後の `COMMAND_MAP` は機能コマンド（制御・書体・色・見出し・参照・リンク）のみに

### 2. amssymb 相当の記号を追加（クラス付き）
- 関係子（Rel）: `\leq` `\geq` `\neq` `\approx` `\equiv` `\cong` `\subseteq` `\supseteq` `\prec` `\succ` `\sqsubseteq` `\vdash` `\models` 他
- 矢印（Rel）: `\rightarrow` `\leftarrow` `\Rightarrow` `\leftrightarrow` `\mapsto` `\hookrightarrow` `\rightleftharpoons` `\longrightarrow` 他
- 二項演算子（Bin）: `\times` `\div` `\pm` `\cdot` `\oplus` `\otimes` `\setminus` `\sqcap` `\dagger` 他
- 大型演算子（Op）: `\bigcap` `\bigcup` `\bigoplus` `\bigotimes` 他
- 名前付き記号（Ord）: `\hbar` `\ell` `\Re` `\Im` `\aleph` `\nabla` 他
- 開き / 閉じ括弧（Open / Close）: `\langle` `\rangle` `\lceil` `\rfloor` 他

### 3. 解決経路の一本化
- `evaluate_command` / `extract_inline_nodes` / `resolve_symbol_command` は `COMMAND_MAP` を引いた後 miss なら `SYMBOL_MAP` を引く（機能コマンド名が記号名に優先）
- `CommandKind` の `SingleChar` / `Undefined` バリアントを削除

### 4. クラスは記録のみ（スペーシングは本 PR では未実装）
- クラスは上流 `unicode-math-table.tex` の `\mathbin` 等から取得して記録するだけ。`MathNode::Symbol` は `char` のまま。将来の数式スペーシング issue（#83 配下）が記号表を作り直さず消費できる

## 設計上の判断
- **「unicode-math 相当」= カバレッジ同等**であって csname 一致ではない。命名は構文設計原則 B に従い分かりやすさ第一で seiran 独自に決定（既存名 `\minus` `\notin` `\land` `\lor` は踏襲）
- `class` フィールドは本 issue では本体コードから読まれないため `#[allow(dead_code)]` を意図的に付与（テストでは検証）

## テスト
- 各記号の `MathClass` 検証（`\leq`→Rel / `\times`→Bin / `\alpha`→Ord / `\sum`→Op / `\langle`→Open 等）
- `COMMAND_MAP` と `SYMBOL_MAP` のキー重複ガード
- 既存記号（`\alpha`）の挙動が不変であること
- amssymb 記号が本文・数式の両文脈で解決されること（`\geq` 本文 / `\leq` 数式）
- 未知コマンドが従来どおりエラーになること

`cargo test`（全クレート）・`cargo clippy --all-targets`・`cargo +nightly fmt` をパス。

## スコープ外（→ #83 / 別 issue）
アクセント（`MathNode::Accent` 新設が必要）、大型演算子の limits 挙動、数式スペーシング、伸縮区切り括弧（#73）、真の根号・縦分数（#67）、unicode-math 全件カバレッジ + 生成スクリプト（#83）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)