### PR TITLE
数式: カリグラフィー（\mathcalligraphic）に対応

### DIFF
--- a/crates/document/src/math.rs
+++ b/crates/document/src/math.rs
@@ -78,6 +78,13 @@ pub enum MathStyle {
   DoubleStruck,
   /// `\mathscript` — スクリプト（roundhand, 花文字）
   Script,
+  /// `\mathcalligraphic` — カリグラフィー（chancery, 花文字の筆記体）
+  ///
+  /// スクリプトと同一の基底コードポイントに異体字セレクタ VS1（U+FE00）を付与して
+  /// chancery 字形を要求する。Unicode の数式異体字シーケンスに対応した数式フォントでのみ
+  /// chancery 字形が選ばれ、非対応フォントでは VS1 が無視されてスクリプト字形に
+  /// フォールバックする（フォント非依存対応は OpenType `ss01` を使う別 issue で行う）。
+  Calligraphic,
   /// `\mathfraktur` — フラクトゥール（ドイツ文字, ℌ ℑ ℜ 等）
   Fraktur,
   /// `\mathscriptbold` — 太字スクリプト（bold roundhand, 花文字の太字）
@@ -121,6 +128,7 @@ impl MathStyle {
       "mathmono" => Some(MathStyle::Mono),
       "mathdoublestruck" => Some(MathStyle::DoubleStruck),
       "mathscript" => Some(MathStyle::Script),
+      "mathcalligraphic" => Some(MathStyle::Calligraphic),
       "mathfraktur" => Some(MathStyle::Fraktur),
       "mathscriptbold" => Some(MathStyle::ScriptBold),
       "mathfrakturbold" => Some(MathStyle::FrakturBold),
@@ -199,7 +207,7 @@ mod tests {
 
   #[test]
   fn math_style_from_command_name_resolves_all_styles() {
-    // Arrange & Act & Assert — 14 個のスタイルコマンドが正しく解決される
+    // Arrange & Act & Assert — 15 個のスタイルコマンドが正しく解決される
     assert_eq!(MathStyle::from_command_name("mathserif"), Some(MathStyle::Serif));
     assert_eq!(MathStyle::from_command_name("mathitalic"), Some(MathStyle::Italic));
     assert_eq!(MathStyle::from_command_name("mathbold"), Some(MathStyle::Bold));
@@ -211,6 +219,7 @@ mod tests {
     assert_eq!(MathStyle::from_command_name("mathmono"), Some(MathStyle::Mono));
     assert_eq!(MathStyle::from_command_name("mathdoublestruck"), Some(MathStyle::DoubleStruck));
     assert_eq!(MathStyle::from_command_name("mathscript"), Some(MathStyle::Script));
+    assert_eq!(MathStyle::from_command_name("mathcalligraphic"), Some(MathStyle::Calligraphic));
     assert_eq!(MathStyle::from_command_name("mathfraktur"), Some(MathStyle::Fraktur));
     assert_eq!(MathStyle::from_command_name("mathscriptbold"), Some(MathStyle::ScriptBold));
     assert_eq!(MathStyle::from_command_name("mathfrakturbold"), Some(MathStyle::FrakturBold));

--- a/crates/lowering/src/math.rs
+++ b/crates/lowering/src/math.rs
@@ -1,15 +1,15 @@
 //! 数式（インライン / ディスプレイ）の lowering
 //!
 //! インライン数式と `\begin{equation}...\end{equation}` のディスプレイ数式を
-//! `LayoutNode` 列に変換します。数式中の文字は [`alphanumeric::translate_math_char`]
-//! によって Unicode Mathematical Alphanumeric Symbols へ変換され、数式フォントが持つ
-//! 字形バリアントを直接呼び出します。
+//! `LayoutNode` 列に変換します。数式中の文字は [`alphanumeric::push_math_char`]
+//! によって Unicode Mathematical Alphanumeric Symbols へ変換され（カリグラフィーは
+//! VS1 異体字セレクタを付与）、数式フォントが持つ字形バリアントを直接呼び出します。
 
 use document::{MathNode, MathRow, MathStyle};
 use read_style::{Alignment, MathScriptStyle as MathStyleConfig, NumberSide};
 use types::{Align, FontKind, MathEnvKind};
 
-use self::alphanumeric::translate_math_char;
+use self::alphanumeric::push_math_char;
 use super::LoweringContext;
 use crate::layout_node::{LayoutNode, MathBlockRow, TextStyle};
 
@@ -124,13 +124,14 @@ fn lower_math_node(
       return lower_math_text(s, font_size, style);
     },
     MathNode::Symbol(ch) => {
-      let translated = translate_math_char(*ch, style);
+      let mut translated = String::new();
+      push_math_char(&mut translated, *ch, style);
       let layout_style = TextStyle {
         font_size,
         font_kind: FontKind::Math,
         color: None,
       };
-      return vec![LayoutNode::Text(translated.to_string(), layout_style)];
+      return vec![LayoutNode::Text(translated, layout_style)];
     },
     MathNode::Group(children) => {
       let mut result = Vec::new();
@@ -202,15 +203,19 @@ fn lower_math_node(
 
 /// 数式中のテキスト文字列を `LayoutNode` 列に変換する
 ///
-/// 文字単位で [`translate_math_char`] を適用してから 1 つの `LayoutNode::Text` にまとめる。
+/// 文字単位で [`push_math_char`] を適用してから 1 つの `LayoutNode::Text` にまとめる。
 /// `FontKind::Math` は常に維持する（テキストフォントへの切替は行わない）。
-/// 数式中に和文が混入した場合のスクリプト別フォント切替は後段の
-/// `split_text_by_script` / `resolve_font_type` が担うため、ここでは分割しない。
+/// カリグラフィーでは基底文字 + VS1 が連続して書き込まれるが、同一文字列に含めることで
+/// 後段のシェーピングが 1 クラスタとして扱う。数式中に和文が混入した場合のスクリプト別
+/// フォント切替は後段の `split_text_by_script` / `resolve_font_type` が担うため、ここでは分割しない。
 fn lower_math_text(text: &str, font_size: f32, style: Option<MathStyle>) -> Vec<LayoutNode> {
   if text.is_empty() {
     return Vec::new();
   }
-  let translated: String = text.chars().map(|c| translate_math_char(c, style)).collect();
+  let mut translated = String::with_capacity(text.len());
+  for c in text.chars() {
+    push_math_char(&mut translated, c, style);
+  }
   let layout_style = TextStyle {
     font_size,
     font_kind: FontKind::Math,
@@ -383,6 +388,29 @@ mod tests {
       })
       .collect();
     assert_eq!(texts, "\u{1D431}\u{1D7CF}\u{1D7D0}\u{1D6C2}");
+  }
+
+  #[test]
+  fn lower_math_node_calligraphic_appends_variation_selector() {
+    // Arrange — \mathcalligraphic{Ab1} 相当: Styled { Calligraphic, [Text("Ab1")] }
+    // 英字はスクリプト基底 + VS1（U+FE00）、数字は素通し
+    let node = MathNode::Styled {
+      style: MathStyle::Calligraphic,
+      body: vec![MathNode::Text("Ab1".to_string())],
+    };
+
+    // Act
+    let result = lower_math_node(&node, 12.0, None, &default_math_style());
+
+    // Assert — "𝒜<VS1>𝒷<VS1>1"（基底はスクリプトと共有、英字のみ VS1 付与）
+    let texts: String = result
+      .iter()
+      .filter_map(|n| match n {
+        LayoutNode::Text(t, _) => Some(t.as_str()),
+        _ => None,
+      })
+      .collect();
+    assert_eq!(texts, "\u{1D49C}\u{FE00}\u{1D4B7}\u{FE00}1");
   }
 
   /// 番号付き 1 行 1 セルの `MathRow` を作るヘルパ

--- a/crates/lowering/src/math/alphanumeric.rs
+++ b/crates/lowering/src/math/alphanumeric.rs
@@ -122,9 +122,11 @@ pub(super) fn translate_math_char(ch: char, style: Option<MathStyle>) -> char {
       }
       return map_digit(ch, 0x1d7d8);
     },
-    Some(MathStyle::Script) => {
-      // スクリプト（roundhand）: 大文字に 8 個・小文字に 3 個の穴。数字・Greek は素通し
-      // chancery（カリグラフィー）は OpenType ss01 が必要なため別途対応する
+    Some(MathStyle::Script | MathStyle::Calligraphic) => {
+      // スクリプト（roundhand）とカリグラフィー（chancery）は同一の基底コードポイントを共有する
+      // （大文字に 8 個・小文字に 3 個の穴。数字・Greek は素通し）。両者の字形差はここでは付けず、
+      // カリグラフィーのみ呼び出し側 `push_math_char` が異体字セレクタ VS1（U+FE00）を付与して
+      // chancery 字形を選ぶ（VS1 はフォント依存。非対応フォントではスクリプト字形にフォールバック）。
       return map_ascii(ch, 0x1d49c, 0x1d4b6, script_hole);
     },
     Some(MathStyle::Fraktur) => {
@@ -139,6 +141,23 @@ pub(super) fn translate_math_char(ch: char, style: Option<MathStyle>) -> char {
       // 太字フラクトゥール: 大文字・小文字とも連続（穴なし）。数字・Greek は素通し
       return map_ascii(ch, 0x1d56c, 0x1d586, no_hole);
     },
+  }
+}
+
+/// 1 文字を `style` に応じて変換し、必要なら異体字セレクタを付けて `out` に書き込む
+///
+/// [`translate_math_char`] が返す基底文字を push したうえで、`style` が
+/// [`MathStyle::Calligraphic`] かつ入力が ASCII 英字のときだけ chancery 異体字セレクタ
+/// VS1（U+FE00）を続けて push する。基底文字 + VS1 を同一の `LayoutNode::Text` 文字列に
+/// 含めることで、後段のシェーピング（harfrust）が 1 クラスタとして処理し、Unicode 数式
+/// 異体字シーケンスに対応した数式フォントで chancery 字形が選ばれる。
+///
+/// 数字・Greek・記号には chancery 異体字が存在しないため VS1 は付与しない。
+/// [`MathStyle::Calligraphic`] 以外のスタイルでは VS1 を一切付与せず、従来挙動を保つ。
+pub(super) fn push_math_char(out: &mut String, ch: char, style: Option<MathStyle>) {
+  out.push(translate_math_char(ch, style));
+  if style == Some(MathStyle::Calligraphic) && ch.is_ascii_alphabetic() {
+    out.push('\u{FE00}');
   }
 }
 
@@ -169,9 +188,11 @@ fn double_struck_hole(ch: char) -> Option<char> {
   };
 }
 
-/// Mathematical Script（スクリプト / カリグラフィー）の穴
+/// Mathematical Script（スクリプト / カリグラフィー共用の基底）の穴
 ///
 /// 大文字 B E F H I L M R と小文字 e g o が Letterlike Symbols に散在する。
+/// スクリプト（roundhand）とカリグラフィー（chancery）は同一の基底コードポイントを共有し、
+/// カリグラフィーはこの基底に VS1 を付けて字形を切り替える（[`push_math_char`] 参照）。
 fn script_hole(ch: char) -> Option<char> {
   return match ch {
     'B' => Some('\u{212C}'), // ℬ
@@ -410,6 +431,51 @@ mod tests {
     assert_eq!(translate_math_char('z', style), '\u{1D503}'); // 小文字 base 末尾
     assert_eq!(translate_math_char('1', style), '1', "太字スクリプト数字は素通し");
     assert_eq!(translate_math_char('α', style), 'α', "太字スクリプト Greek は Unicode 未定義のため素通し");
+  }
+
+  #[test]
+  fn translate_calligraphic_reuses_script_codepoints() {
+    // Arrange & Act & Assert — カリグラフィーの基底はスクリプトと同一（穴も共有）。VS1 は別途付与
+    let cal = Some(MathStyle::Calligraphic);
+    let script = Some(MathStyle::Script);
+    assert_eq!(translate_math_char('A', cal), translate_math_char('A', script));
+    assert_eq!(translate_math_char('A', cal), '\u{1D49C}'); // 連続
+    assert_eq!(translate_math_char('B', cal), '\u{212C}'); // ℬ (穴)
+    assert_eq!(translate_math_char('e', cal), '\u{212F}'); // ℯ (穴)
+    assert_eq!(translate_math_char('z', cal), '\u{1D4CF}'); // 小文字 base 末尾
+    assert_eq!(translate_math_char('1', cal), '1', "カリグラフィー数字は素通し");
+    assert_eq!(translate_math_char('α', cal), 'α', "カリグラフィー Greek は素通し");
+  }
+
+  #[test]
+  fn push_math_char_appends_vs1_only_for_calligraphic_letters() {
+    // Arrange — カリグラフィーは ASCII 英字に VS1 (U+FE00) を付与、数字・Greek には付けない
+    let cal = Some(MathStyle::Calligraphic);
+
+    // Act & Assert
+    let mut a = String::new();
+    push_math_char(&mut a, 'A', cal);
+    assert_eq!(a, "\u{1D49C}\u{FE00}", "カリグラフィー英字は基底 + VS1");
+
+    let mut hole = String::new();
+    push_math_char(&mut hole, 'B', cal);
+    assert_eq!(hole, "\u{212C}\u{FE00}", "Letterlike の穴文字にも VS1 を付与");
+
+    let mut digit = String::new();
+    push_math_char(&mut digit, '1', cal);
+    assert_eq!(digit, "1", "数字には VS1 を付けない");
+  }
+
+  #[test]
+  fn push_math_char_keeps_other_styles_unchanged() {
+    // Arrange & Act & Assert — カリグラフィー以外は VS1 を一切付けず従来挙動（単一コードポイント）
+    let mut script = String::new();
+    push_math_char(&mut script, 'A', Some(MathStyle::Script));
+    assert_eq!(script, "\u{1D49C}", "スクリプトは VS1 無し（既存挙動不変）");
+
+    let mut default = String::new();
+    push_math_char(&mut default, 'x', None);
+    assert_eq!(default, "\u{1D465}", "デフォルトは italic 化のみ");
   }
 
   #[test]

--- a/crates/parser/tests/evaluate.rs
+++ b/crates/parser/tests/evaluate.rs
@@ -484,10 +484,11 @@ fn evaluate_inline_math_styled_sans_bold_italic_with_greek() {
 
 #[test]
 fn evaluate_inline_math_styled_math_alphabets_resolve() {
-  // Arrange — 数学字体 5 コマンドが対応する MathStyle の Styled に解決される
-  let cases: [(&str, MathStyle); 5] = [
+  // Arrange — 数学字体 6 コマンドが対応する MathStyle の Styled に解決される
+  let cases: [(&str, MathStyle); 6] = [
     ("mathdoublestruck", MathStyle::DoubleStruck),
     ("mathscript", MathStyle::Script),
+    ("mathcalligraphic", MathStyle::Calligraphic),
     ("mathfraktur", MathStyle::Fraktur),
     ("mathscriptbold", MathStyle::ScriptBold),
     ("mathfrakturbold", MathStyle::FrakturBold),

--- a/tests/text/equation.sei
+++ b/tests/text/equation.sei
@@ -34,4 +34,7 @@ Letterlike Symbols に散る穴を含めて正しいグリフへ変換される�
 
 スクリプト（花文字）$\mathscript{ABFHL}$ も大文字の穴を含めて変換される。
 
+カリグラフィー $\mathcalligraphic{ABFHL}$ はスクリプトと同じ基底に異体字セレクタ VS1 を付与し、
+対応フォントでは chancery 字形になる（非対応フォントではスクリプト字形にフォールバックする）。
+
 太字スクリプト $\mathscriptbold{ABC}$ と太字フラクトゥール $\mathfrakturbold{abc}$ は太字字形で出力される。


### PR DESCRIPTION
## 概要

数式のカリグラフィー（chancery 字形）を `\mathcalligraphic` で出力できるようにする。

Unicode ではカリグラフィー（chancery）とスクリプト（roundhand）は **同じ基底コードポイント**
（U+1D49C..U+1D4CF + Letterlike の穴 ℬℰℱℋℐℒℳℛ ℯℊℴ）を共有し、**異体字セレクタ**で字形を切り替える:

- 基底 + **VS1（U+FE00）** → chancery（= カリグラフィー）
- 基底 + VS2（U+FE01） → roundhand（= 既存 `\mathscript`）

本 PR は **VS1 方式**でカリグラフィーを実装する。

## 変更内容

- **document** (`crates/document/src/math.rs`): `MathStyle` に `Calligraphic` を追加し、
  `from_command_name` で `"mathcalligraphic"` を解決。
- **lowering** (`crates/lowering/src/math/alphanumeric.rs`, `math.rs`):
  - `translate_math_char` の `Calligraphic` 腕はスクリプトと **基底コードポイントを共有**（穴も共有）。
  - 新ヘルパ `push_math_char` が ASCII 英字にのみ **VS1（U+FE00）を付与**（数字・Greek・記号には付けない）。
  - 基底 + VS1 を **同一の `LayoutNode::Text` 文字列**に含めることで、後段のシェーピング（harfrust）が
    1 クラスタとして処理する（VS1 は Script=Inherited なのでセグメント分割もされない）。
  - 既存の `lower_math_text` / `MathNode::Symbol` の経路を `push_math_char` 経由に統一。
- 命名は構文設計原則 B（分かりやすさ第一・略語回避）に従い **`\mathcalligraphic`**
  （既存の `mathscript` / `mathdoublestruck` と同系統の記述名）。

## フォント依存性（明記）

VS1 はフォントが **Unicode 数式異体字シーケンス（cmap format 14 / UVS）** に対応している場合のみ
chancery 字形を選ぶ。**非対応フォントでは VS1 が無視され、スクリプト字形にフォールバック**する
（.notdef にはならない）。

- 既定の **STIX Two Math は UVS 対応**（VS1 マッピング 25 件を確認済み）→ chancery が出る。
- Latin Modern Math 等の UVS 非対応フォントでは chancery にならない。

→ フォント非依存に chancery を出す **OpenType `ss01` 方式**は別 issue #89 で対応する。

## テスト

- `MathStyle::from_command_name` の解決（14 → 15 スタイル）。
- カリグラフィーの基底がスクリプトと一致（`A→U+1D49C` / `B→ℬ` / `e→ℯ`、数字・Greek 素通し）。
- `push_math_char` の VS1 付与: カリグラフィー英字 → 基底 + VS1、数字 → VS1 なし、
  スクリプト/デフォルト → VS1 なし（**既存挙動の不変性**）。
- lowering 出力で `\mathcalligraphic{Ab1}` → `𝒜<VS1>𝒷<VS1>1`。
- parser 統合テスト（`$\mathcalligraphic{R}$` → `MathNode::Styled{Calligraphic}`）。
- `tests/text/equation.sei` に実例を追加。`cargo run -- build`（STIX Two Math）でパイプラインが
  クラッシュせず PDF 生成できることを確認。

`cargo test`（全クレート）・`cargo clippy --all-targets`（無警告）・`cargo +nightly fmt` をパス。

## スコープ外
- OpenType `ss01` 方式（フォント非依存対応） → #89
- 既存 `\mathscript` への VS2 明示付与（フォント既定に委ねたまま据え置き）

🤖 Generated with [Claude Code](https://claude.com/claude-code)