### PR TITLE
定理: proof の of 参照を見出しに反映（Proof of Theorem 1）

### DIFF
--- a/crates/lowering/src/lib.rs
+++ b/crates/lowering/src/lib.rs
@@ -215,12 +215,13 @@ fn lower_node_indexed(
       number,
       title,
       body,
+      of,
       label,
-      ..
     } => {
       // 見出し（独立行）＋ クラス別 font_kind 本文 ＋ 上下マージン、proof は末尾に QED。
-      // `of`（証明対象の見出し反映）は本実装では未対応（スタイルスキーマ拡張が前提・別 issue）。
-      return theorem::lower_theorem(ctx, *class, number.as_deref(), title.as_deref(), body, label.as_deref());
+      // proof の `of` は pass2 で解決済みの cleveref 文字列（例「Theorem 1」）を見出しに織り込む。
+      let of = of.as_ref().and_then(|target| target.number.as_deref());
+      return theorem::lower_theorem(ctx, *class, number.as_deref(), title.as_deref(), body, of, label.as_deref());
     },
     DocNode::Rule { width, height } => {
       return Ok(vec![LayoutNode::Rule {

--- a/crates/lowering/src/theorem.rs
+++ b/crates/lowering/src/theorem.rs
@@ -16,6 +16,8 @@ use crate::layout_node::{LayoutNode, TextStyle};
 ///
 /// 構成: `Vkern(top_margin)` → 見出し `VBox` → 本体（`body_font_kind` 上書き）→ `Vkern(bottom_margin)`。
 /// `label` が `Some` のとき先頭に `\ref` 到達先アンカー（[`with_label_anchor`]）を付ける。
+/// `of` は `proof` の証明対象（pass2 で解決済みの cleveref 文字列、例「Theorem 1」）で、
+/// `Some` のとき見出しを「Proof of Theorem 1」相当に組む。
 ///
 /// # Errors
 ///
@@ -26,6 +28,7 @@ pub(super) fn lower_theorem(
   number: Option<&str>,
   title: Option<&str>,
   body: &[DocNode],
+  of: Option<&str>,
   label: Option<&str>,
 ) -> Result<Vec<LayoutNode>, LoweringError> {
   let theorem_style = ctx.style.theorem(class);
@@ -35,7 +38,7 @@ pub(super) fn lower_theorem(
     LayoutNode::Vkern {
       length: pres.top_margin,
     },
-    build_heading(ctx, theorem_style, number, title)?,
+    build_heading(ctx, theorem_style, number, title, of)?,
   ];
 
   // 本体はクラス別 font_kind（定理は斜体・証明や定義系はローマン）を既定書体にする
@@ -65,14 +68,17 @@ pub(super) fn lower_theorem(
 
 /// 定理見出し（独立行）の `VBox` を構築する
 ///
-/// `title` の有無で `heading_with_title` / `heading_format` を選び、`{display_name}` を素朴置換
-/// してから [`expand_template`] で `{number}` / `{title}` を解決する。書体は `heading_font_kind`、
-/// サイズは本文と同じ（`TheoremPresentation` に見出し専用サイズは無い）。
+/// `of`（証明対象）と `title`（サブタイトル）の有無の 4 通りで
+/// `heading_with_of_and_title` / `heading_with_of` / `heading_with_title` / `heading_format` を選び、
+/// プレーン文字列の `{display_name}` / `{of}` を素朴置換してから [`expand_template`] で
+/// `{number}` / `{title}` を解決する。書体は `heading_font_kind`、サイズは本文と同じ
+/// （`TheoremPresentation` に見出し専用サイズは無い）。
 fn build_heading(
   ctx: &LoweringContext,
   theorem_style: &TheoremStyle,
   number: Option<&str>,
   title: Option<&str>,
+  of: Option<&str>,
 ) -> Result<LayoutNode, LoweringError> {
   let pres = &theorem_style.style;
   let base_style = TextStyle {
@@ -81,13 +87,17 @@ fn build_heading(
     color: None,
   };
 
-  // `{display_name}` は expand_template 非対応なので先に素朴置換する（プレーン文字列）
-  let raw_template = if title.is_some() {
-    &pres.heading_with_title
-  } else {
-    &pres.heading_format
+  // 証明対象（`of`）とサブタイトル（`title`）の有無でテンプレートを選ぶ。`of` は proof のみ。
+  let raw_template = match (of.is_some(), title.is_some()) {
+    (true, true) => &pres.heading_with_of_and_title,
+    (true, false) => &pres.heading_with_of,
+    (false, true) => &pres.heading_with_title,
+    (false, false) => &pres.heading_format,
   };
-  let template = raw_template.replace("{display_name}", &theorem_style.display_name);
+  // `{display_name}` / `{of}` は expand_template 非対応なので先に素朴置換する（いずれもプレーン文字列）
+  let template = raw_template
+    .replace("{display_name}", &theorem_style.display_name)
+    .replace("{of}", of.unwrap_or(""));
 
   let title_inlines: Vec<InlineNode> = title.map(|t| vec![InlineNode::Text(t.to_string())]).unwrap_or_default();
 
@@ -149,8 +159,8 @@ mod tests {
     let ctx = LoweringContext::new(&style);
 
     // Act
-    let nodes =
-      lower_theorem(&ctx, TheoremClass::Theorem, Some("1"), None, &[paragraph("body")], None).expect("失敗しないはず");
+    let nodes = lower_theorem(&ctx, TheoremClass::Theorem, Some("1"), None, &[paragraph("body")], None, None)
+      .expect("失敗しないはず");
 
     // Assert — 見出しは "Theorem 1"・太字、本体は斜体、上下に Vkern
     let (heading, heading_style) = first_heading_text(&nodes);
@@ -175,8 +185,9 @@ mod tests {
     // Arrange / Act — title 付きは heading_with_title（"{display_name} {number} ({title})"）
     let style = ReadStyle::default();
     let ctx = LoweringContext::new(&style);
-    let nodes = lower_theorem(&ctx, TheoremClass::Theorem, Some("2"), Some("Pythagoras"), &[paragraph("x")], None)
-      .expect("失敗しないはず");
+    let nodes =
+      lower_theorem(&ctx, TheoremClass::Theorem, Some("2"), Some("Pythagoras"), &[paragraph("x")], None, None)
+        .expect("失敗しないはず");
 
     // Assert
     let (heading, _) = first_heading_text(&nodes);
@@ -191,7 +202,7 @@ mod tests {
 
     // Act
     let nodes =
-      lower_theorem(&ctx, TheoremClass::Proof, None, None, &[paragraph("qed")], None).expect("失敗しないはず");
+      lower_theorem(&ctx, TheoremClass::Proof, None, None, &[paragraph("qed")], None, None).expect("失敗しないはず");
 
     // Assert
     let (heading, _) = first_heading_text(&nodes);
@@ -216,7 +227,7 @@ mod tests {
 
     // Act
     let nodes =
-      lower_theorem(&ctx, TheoremClass::Proof, None, None, &[paragraph("last")], None).expect("失敗しないはず");
+      lower_theorem(&ctx, TheoremClass::Proof, None, None, &[paragraph("last")], None, None).expect("失敗しないはず");
 
     // Assert — FlushRight の直後は Vkern（最終段落と同居 = 段落の途中に置かれている）
     let qed_idx = nodes.iter().position(|n| matches!(n, LayoutNode::FlushRight(_))).expect("QED があるはず");
@@ -237,7 +248,7 @@ mod tests {
     };
 
     // Act
-    let nodes = lower_theorem(&ctx, TheoremClass::Proof, None, None, &[list], None).expect("失敗しないはず");
+    let nodes = lower_theorem(&ctx, TheoremClass::Proof, None, None, &[list], None, None).expect("失敗しないはず");
 
     // Assert — FlushRight は末尾の bottom_margin Vkern の直前（= 全体の最後から 2 番目）
     let qed_idx = nodes.iter().position(|n| matches!(n, LayoutNode::FlushRight(_))).expect("QED があるはず");
@@ -246,11 +257,66 @@ mod tests {
   }
 
   #[test]
+  fn proof_with_of_renders_proof_of_target_heading() {
+    // Arrange — of=「Theorem 1」（pass2 解決済み）を持つ proof
+    let style = ReadStyle::default();
+    let ctx = LoweringContext::new(&style);
+
+    // Act
+    let nodes = lower_theorem(&ctx, TheoremClass::Proof, None, None, &[paragraph("x")], Some("Theorem 1"), None)
+      .expect("失敗しないはず");
+
+    // Assert — 見出しは "Proof of Theorem 1"
+    let (heading, _) = first_heading_text(&nodes);
+    assert_eq!(heading, "Proof of Theorem 1");
+  }
+
+  #[test]
+  fn proof_without_of_keeps_plain_proof_heading() {
+    // Arrange / Act — of=None の proof は従来どおり "Proof"
+    let style = ReadStyle::default();
+    let ctx = LoweringContext::new(&style);
+    let nodes =
+      lower_theorem(&ctx, TheoremClass::Proof, None, None, &[paragraph("x")], None, None).expect("失敗しないはず");
+
+    // Assert
+    let (heading, _) = first_heading_text(&nodes);
+    assert_eq!(heading, "Proof");
+  }
+
+  #[test]
+  fn proof_with_of_and_title_combines_both() {
+    // Arrange / Act — of と title を併用: of を先に、title を括弧で後置する
+    let style = ReadStyle::default();
+    let ctx = LoweringContext::new(&style);
+    let nodes =
+      lower_theorem(&ctx, TheoremClass::Proof, None, Some("sketch"), &[paragraph("x")], Some("Theorem 1"), None)
+        .expect("失敗しないはず");
+
+    // Assert
+    let (heading, _) = first_heading_text(&nodes);
+    assert_eq!(heading, "Proof of Theorem 1 (sketch)");
+  }
+
+  #[test]
+  fn proof_with_title_only_ignores_of_templates() {
+    // Arrange / Act — of なし・title あり: heading_with_title（"Proof (title)"）が選ばれる
+    let style = ReadStyle::default();
+    let ctx = LoweringContext::new(&style);
+    let nodes = lower_theorem(&ctx, TheoremClass::Proof, None, Some("sketch"), &[paragraph("x")], None, None)
+      .expect("失敗しないはず");
+
+    // Assert
+    let (heading, _) = first_heading_text(&nodes);
+    assert_eq!(heading, "Proof (sketch)");
+  }
+
+  #[test]
   fn theorem_with_label_prepends_anchor() {
     // Arrange / Act — label 付きは先頭に AnchorMark::Label を出す
     let style = ReadStyle::default();
     let ctx = LoweringContext::new(&style);
-    let nodes = lower_theorem(&ctx, TheoremClass::Theorem, Some("1"), None, &[paragraph("b")], Some("thm:x"))
+    let nodes = lower_theorem(&ctx, TheoremClass::Theorem, Some("1"), None, &[paragraph("b")], None, Some("thm:x"))
       .expect("失敗しないはず");
 
     // Assert

--- a/crates/read_style/src/theorem.rs
+++ b/crates/read_style/src/theorem.rs
@@ -179,6 +179,19 @@ pub struct TheoremPresentation {
   /// サブタイトルありの見出し書式。`{display_name}` / `{number}` / `{title}` を含められる
   #[garde(length(chars, min = 1))]
   pub heading_with_title: String,
+  /// 証明対象（`of`）ありサブタイトルなしの見出し書式。`{display_name}` / `{of}` を含められる。
+  ///
+  /// `proof` の `[of=...]` 指定時にのみ選択される（`{of}` は対象定理の cleveref 文字列
+  /// ＝「Theorem 1」等に解決される）。前置語「of」を含む結合書式ごとこのフィールドで上書きでき、
+  /// 国際化（`{display_name}（{of} の証明）` 等）も可能。`proof` 以外のクラスでは `of` を取れないため未使用。
+  #[garde(length(chars, min = 1))]
+  pub heading_with_of: String,
+  /// 証明対象（`of`）ありサブタイトルありの見出し書式。`{display_name}` / `{of}` / `{title}` を含められる。
+  ///
+  /// `of` と `title` を併用したときの結合書式。既定は `of` を先に、`title` を括弧で後置する
+  /// （「Proof of Theorem 1 (…)」）。
+  #[garde(length(chars, min = 1))]
+  pub heading_with_of_and_title: String,
   /// 本文のフォント種別（定理は斜体、証明・定義系はローマン）
   pub font_kind: FontKind,
   /// 見出しのフォント種別（既定は太字セリフ）
@@ -192,11 +205,13 @@ pub struct TheoremPresentation {
 }
 
 impl Default for TheoremPresentation {
-  /// 既定値: `"{display_name} {number}"` / 本文斜体・見出し太字 / 上下 12pt。
+  /// 既定値: `"{display_name} {number}"`（`of` ありは `"{display_name} of {of}"`）/ 本文斜体・見出し太字 / 上下 12pt。
   fn default() -> Self {
     return Self {
       heading_format: "{display_name} {number}".to_string(),
       heading_with_title: "{display_name} {number} ({title})".to_string(),
+      heading_with_of: "{display_name} of {of}".to_string(),
+      heading_with_of_and_title: "{display_name} of {of} ({title})".to_string(),
       font_kind: FontKind::SerifItalic,
       heading_font_kind: FontKind::SerifBold,
       top_margin: Length::pt(12.0),
@@ -362,6 +377,10 @@ pub struct TheoremPresentationOverride {
   pub heading_format: Option<String>,
   /// サブタイトルありの見出し書式
   pub heading_with_title: Option<String>,
+  /// 証明対象（`of`）ありサブタイトルなしの見出し書式
+  pub heading_with_of: Option<String>,
+  /// 証明対象（`of`）ありサブタイトルありの見出し書式
+  pub heading_with_of_and_title: Option<String>,
   /// 本文のフォント種別
   pub font_kind: Option<FontKind>,
   /// 見出しのフォント種別
@@ -380,6 +399,12 @@ impl TheoremPresentationOverride {
     }
     if let Some(heading_with_title) = &self.heading_with_title {
       target.heading_with_title.clone_from(heading_with_title);
+    }
+    if let Some(heading_with_of) = &self.heading_with_of {
+      target.heading_with_of.clone_from(heading_with_of);
+    }
+    if let Some(heading_with_of_and_title) = &self.heading_with_of_and_title {
+      target.heading_with_of_and_title.clone_from(heading_with_of_and_title);
     }
     if let Some(font_kind) = self.font_kind {
       target.font_kind = font_kind;
@@ -568,6 +593,32 @@ font_kind = \"sans_serif_bold\"
     assert_eq!(theorem.style.font_kind, FontKind::SansSerifBold);
     assert_eq!(theorem.style.heading_format, "{display_name} {number}");
     assert!((theorem.style.top_margin.to_pt() - 12.0).abs() < f32::EPSILON);
+  }
+
+  #[test]
+  fn default_proof_of_templates_render_proof_of_target() {
+    // Arrange / Act — proof の of テンプレート既定（generic default を継承）
+    let proof = default_for_class(TheoremClass::Proof);
+
+    // Assert — of ありは「Proof of {of}」、of＋title 併用は括弧で後置
+    assert_eq!(proof.style.heading_with_of, "{display_name} of {of}");
+    assert_eq!(proof.style.heading_with_of_and_title, "{display_name} of {of} ({title})");
+  }
+
+  #[test]
+  fn override_proof_of_template_localizes_prefix() {
+    // Arrange: 前置語「of」を日本語化する上書き
+    let toml = "
+[theorems.proof.style]
+heading_with_of = \"{display_name}（{of} の証明）\"
+";
+
+    // Act
+    let wrapper: TheoremsWrapper = toml::from_str(toml).unwrap();
+
+    // Assert: of テンプレートだけ変わり、他は既定を維持
+    assert_eq!(wrapper.theorems.proof.style.heading_with_of, "{display_name}（{of} の証明）");
+    assert_eq!(wrapper.theorems.proof.style.heading_with_of_and_title, "{display_name} of {of} ({title})");
   }
 
   #[test]


### PR DESCRIPTION
## 概要

`\begin{proof}[of=thm:x]` の `of` 参照を証明の見出しに反映し、「Proof of Theorem 1」のように証明対象を明示できるようにする。

これまで `of` は parser で受理され pass2（`resolve_refs`）で cleveref 文字列（例「Theorem 1」）に解決されるところまで動いていたが、lowering が `of` を無視するため見出しは「Proof」のままだった。**受理・検証されるのに視覚的効果がゼロ**で、利用者に「`of` が効いていない／壊れている」と誤解させる状態を解消する。

## 変更内容

- **read_style** (`theorem.rs`): `TheoremPresentation` に `of` 対応の見出しテンプレート 2 種を追加。
  - `heading_with_of`（既定 `"{display_name} of {of}"`）— `of` あり・`title` なし
  - `heading_with_of_and_title`（既定 `"{display_name} of {of} ({title})"`）— `of`・`title` 併用
  - 既存の 2 レイヤーマージ（Rust 既定 → `[theorems.<class>.style]` 差分）・`Override`・garde 検証に組み込み、前置語「of」を含む結合書式を `style.toml` で上書き可能（i18n 対応）にした。`{of}` は対象定理の cleveref 文字列に解決される。
- **lowering** (`lib.rs` / `theorem.rs`): 落としていた `of` を解決済み文字列として `lower_theorem` に渡し、`build_heading` で `(of, title)` の有無 4 通りでテンプレートを選択。`{of}` は `{display_name}` 同様、`expand_template` 前にプレーン置換する。
- **`title` と `of` の併用規則**: `of` を先・`title` を括弧で後置（「Proof of Theorem 1 (…)」）に固定。

`of` は parser が `proof` 専用に限定しており、他クラスでは取れないため、追加テンプレートは proof でのみ選択される。未解決ラベルは従来どおり pass2 の `UnknownLabel` でエラーになる。

## テスト

- lowering: `of` あり→「Proof of Theorem 1」/ `of` なし→「Proof」/ `of`+`title` 併用 / `title` のみ の 4 ケースを追加。
- read_style: of テンプレートの既定値と前置語ローカライズ上書きを追加。
- E2E: `tests/text/theorem.sei` から PDF を生成し、`pdftotext` で「Proof of Theorem 1」（of あり）と「Proof」（of なし）の両方をレンダリング確認。
- `cargo test`（全 workspace）/ `cargo clippy --workspace` / `cargo +nightly fmt --check` すべて green。

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)