### PR TITLE
設定: フォーマットテンプレート/走り文トークンの未知プレースホルダを検証で弾く

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1810,6 +1810,7 @@ dependencies = [
  "garde",
  "miette",
  "serde",
+ "tempfile",
  "thiserror",
  "toml",
  "tracing",

--- a/crates/read_style/Cargo.toml
+++ b/crates/read_style/Cargo.toml
@@ -16,5 +16,8 @@ toml.workspace = true
 tracing.workspace = true
 types.workspace = true
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [lints]
 workspace = true

--- a/crates/read_style/src/caption.rs
+++ b/crates/read_style/src/caption.rs
@@ -17,7 +17,7 @@ use types::length::{Length, positive};
 #[serde(deny_unknown_fields, default)]
 pub struct CaptionStyle {
   /// キャプションの書式テンプレート。`{number}` と `{title}` を含めることができる
-  #[garde(length(chars, min = 1))]
+  #[garde(length(chars, min = 1), custom(crate::placeholder::caption_format))]
   pub format: String,
   /// キャプションのフォントサイズ
   #[garde(custom(positive))]

--- a/crates/read_style/src/counter.rs
+++ b/crates/read_style/src/counter.rs
@@ -172,7 +172,7 @@ pub struct CounterStyle {
   /// 番号テンプレート。`{n}` で自身、`{<counter_name>}` で他カウンタの値を埋め込む
   ///
   /// 例: `"{n}"`（単独）、`"{chapter}.{n}"`（章番号と連結）、`"第{n}章"`（装飾付き）
-  #[garde(length(chars, min = 1))]
+  #[garde(length(chars, min = 1), custom(crate::placeholder::counter_format))]
   pub format: String,
   /// 各プレースホルダの数字表記スタイル（参照先カウンタは参照先のスタイルが使われる）
   pub number_style: NumberStyle,
@@ -180,7 +180,7 @@ pub struct CounterStyle {
   /// 種別名を埋め込む
   ///
   /// 例: `"{display_name} {number}"` → `"Section 1.2"`、`"({number})"` → `"(1.2)"`
-  #[garde(length(chars, min = 1))]
+  #[garde(length(chars, min = 1), custom(crate::placeholder::ref_format))]
   pub ref_format: String,
   /// このカウンタが進んだときに 0 にリセットする下位カウンタ群
   pub resets: Vec<CounterName>,
@@ -232,6 +232,22 @@ pub enum CounterName {
 }
 
 impl CounterName {
+  /// 固定 9 種のカウンタ名を宣言順（部 → 章 → … → 数式）で並べた配列。
+  ///
+  /// プレースホルダ検証（`crate::placeholder`）が `{<counter_name>}` 参照の許可セットを
+  /// 構築する際の単一ソースとして使う。
+  pub const ALL: [CounterName; 9] = [
+    Self::Part,
+    Self::Chapter,
+    Self::Section,
+    Self::Subsection,
+    Self::Paragraph,
+    Self::Subparagraph,
+    Self::Table,
+    Self::Figure,
+    Self::Equation,
+  ];
+
   /// `snake_case` の文字列表現を返す（TOML のキーと同じ）
   #[must_use]
   pub fn as_str(self) -> &'static str {

--- a/crates/read_style/src/equation.rs
+++ b/crates/read_style/src/equation.rs
@@ -10,7 +10,7 @@ use types::length::{Length, non_negative};
 #[serde(deny_unknown_fields, default)]
 pub struct EquationStyle {
   /// 数式番号の書式テンプレート。`{number}` を含めることができる
-  #[garde(length(chars, min = 1))]
+  #[garde(length(chars, min = 1), custom(crate::placeholder::equation_number_format))]
   pub number_format: String,
   /// 数式番号の配置側
   pub number_side: NumberSide,

--- a/crates/read_style/src/error.rs
+++ b/crates/read_style/src/error.rs
@@ -55,4 +55,36 @@ pub enum ValidationError {
     /// 不正の内容
     message: String,
   },
+
+  /// `csl_path`（CSL スタイルファイル）の正規化（`canonicalize`）失敗。
+  ///
+  /// ファイルが存在しない・読み取り権限が無い等で絶対パスへ解決できなかった場合に発生する。
+  #[error("CSL スタイルファイルのパスを正規化できませんでした: {path}")]
+  #[diagnostic(
+    code(style::validation::csl_path_resolution),
+    help("style.toml の [reference].csl_path が指すファイルが存在し、読み取り権限があることを確認してください。")
+  )]
+  CslPathResolution {
+    /// 正規化に失敗したパス
+    path: String,
+    /// 元の I/O エラー
+    #[source]
+    source: std::io::Error,
+  },
+
+  /// `locale_path`（CSL ロケールファイル）の正規化（`canonicalize`）失敗。
+  ///
+  /// ファイルが存在しない・読み取り権限が無い等で絶対パスへ解決できなかった場合に発生する。
+  #[error("CSL ロケールファイルのパスを正規化できませんでした: {path}")]
+  #[diagnostic(
+    code(style::validation::locale_path_resolution),
+    help("style.toml の [reference].locale_path が指すファイルが存在し、読み取り権限があることを確認してください。")
+  )]
+  LocalePathResolution {
+    /// 正規化に失敗したパス
+    path: String,
+    /// 元の I/O エラー
+    #[source]
+    source: std::io::Error,
+  },
 }

--- a/crates/read_style/src/heading.rs
+++ b/crates/read_style/src/heading.rs
@@ -103,7 +103,7 @@ impl HeadingStyles {
 #[serde(deny_unknown_fields, default)]
 pub struct HeadingStyle {
   /// 見出しの書式テンプレート。`{number}` と `{title}` を含めることができる
-  #[garde(length(chars, min = 1))]
+  #[garde(length(chars, min = 1), custom(crate::placeholder::heading_format))]
   pub format: String,
   /// 見出しテキストのフォントサイズ
   #[garde(custom(positive))]
@@ -262,6 +262,18 @@ mod tests {
   use types::{FontKind, HeadingLevel, length::Length};
 
   use super::{HeadingStyle, HeadingStyles, default_for_level};
+
+  #[test]
+  fn validate_rejects_unknown_placeholder_in_format() {
+    // Arrange: `{number}` のタイポ `{nubmer}` を含む書式
+    let style = HeadingStyle {
+      format: "{nubmer} {title}".to_string(),
+      ..HeadingStyle::default()
+    };
+
+    // Act / Assert
+    assert!(style.validate().is_err());
+  }
 
   /// `HeadingStyles` を TOML から `[heading.<level>]` 配下に書く形でテストするための薄いラッパ。
   /// 本番では `Style.heading` が同形でこの型を保持する。

--- a/crates/read_style/src/lib.rs
+++ b/crates/read_style/src/lib.rs
@@ -1,7 +1,9 @@
 //! TOML スタイル設定ファイルのパース・検証モジュール
 //!
 //! [`read_style`] が指定されたパスのスタイル設定ファイルを読み込み、`toml` クレートで
-//! デシリアライズしてから `garde` で値検証を行い [`Style`] を返します。
+//! デシリアライズしてから `garde` で値検証を行い [`Style`] を返します。値検証の後、ロケール
+//! コードを標準形へ正規化し（[`parse_style`]）、`csl_path` / `locale_path` を `canonicalize` で
+//! 絶対パスへ正規化しつつ存在を検証します（[`read_style`]、I/O フェーズ）。
 //! パスが `None` の場合はファイルを読まずに [`Style::default`] を返します。
 //!
 //! 既定値は各サブ struct の [`Default`] 実装が提供し、TOML 側は `#[serde(default)]` で
@@ -30,6 +32,7 @@ pub mod title_page;
 pub mod toc;
 
 mod error;
+mod placeholder;
 mod style;
 
 use std::{fs, path::Path};
@@ -69,7 +72,8 @@ pub use crate::{
 ///
 /// - ファイルが読めない場合は [`ReadStyleError::ReadFile`]
 /// - TOML 解析に失敗した場合は [`ReadStyleError::ParseToml`]
-/// - 値検証に違反した場合は [`ReadStyleError::MultipleValidationErrors`]
+/// - 値検証違反、または `csl_path` / `locale_path` の正規化（`canonicalize`）失敗の場合は
+///   [`ReadStyleError::MultipleValidationErrors`]
 // 設定ファイルは 1 回しか読まないため、Result サイズを最適化する価値が低い。
 #[allow(clippy::result_large_err)]
 pub fn read_style(path: Option<&Path>) -> Result<Style, ReadStyleError> {
@@ -85,7 +89,14 @@ pub fn read_style(path: Option<&Path>) -> Result<Style, ReadStyleError> {
     source,
   })?;
 
-  let style = parse_style(&content, &path_str)?;
+  let mut style = parse_style(&content, &path_str)?;
+
+  // CSL 関連パス（csl_path / locale_path）を canonicalize で絶対パスへ正規化し、存在を検証する
+  // （I/O フェーズ。純粋処理の parse_style とは分離する）。
+  let errors = resolve_reference_paths(&mut style.reference);
+  if !errors.is_empty() {
+    return Err(ReadStyleError::MultipleValidationErrors { errors });
+  }
 
   info!(
     font_size_pt = style.font_size.to_pt(),
@@ -95,9 +106,11 @@ pub fn read_style(path: Option<&Path>) -> Result<Style, ReadStyleError> {
   return Ok(style);
 }
 
-/// TOML 文字列を [`Style`] にパースし、値検証まで実行します（I/O なし）。
+/// TOML 文字列を [`Style`] にパースし、値検証とロケールコードの正規化まで実行します（I/O なし）。
 ///
 /// 未指定フィールドは `#[serde(default)]` 経由で [`Style::default`] の値が入ります。
+/// 値検証の通過後に [`ReferenceStyle::normalize`] でロケールコードを標準形へ揃えます
+/// （パスの `canonicalize` は I/O を伴うため [`read_style`] 側で行います）。
 ///
 /// # Errors
 ///
@@ -107,7 +120,7 @@ pub fn read_style(path: Option<&Path>) -> Result<Style, ReadStyleError> {
 pub fn parse_style(content: &str, source_path: &str) -> Result<Style, ReadStyleError> {
   // `Style` は `#[serde(deny_unknown_fields)]` を持つため、未知のトップレベルキーは
   // この toml::from_str がそのまま span 付きで弾く。
-  let style: Style = toml::from_str(content).map_err(|source| {
+  let mut style: Style = toml::from_str(content).map_err(|source| {
     let src = NamedSource::new(source_path, content.to_string());
     let span = source.span().map_or_else(
       || SourceSpan::new(0.into(), 0),
@@ -118,6 +131,8 @@ pub fn parse_style(content: &str, source_path: &str) -> Result<Style, ReadStyleE
   if let Err(errors) = validate_values(&style) {
     return Err(ReadStyleError::MultipleValidationErrors { errors });
   }
+  // 値検証の通過後にロケールコードを標準形へ正規化する（純粋処理）。
+  style.reference.normalize();
   return Ok(style);
 }
 
@@ -167,4 +182,90 @@ fn validate_values(style: &Style) -> Result<(), Vec<ValidationError>> {
     return Ok(());
   }
   return Err(errors);
+}
+
+/// `style.reference` の CSL 関連パス（`csl_path` / `locale_path`）を `canonicalize` で絶対パスへ
+/// 正規化し、ファイルの存在を同時に検証します（I/O フェーズ）。
+///
+/// 相対パスは `read_config` のパス解決（`style_path` / `references_path` 等）と同様にカレント
+/// ディレクトリ基準で解決します。解決できなかったパスは [`ValidationError`] に積んで返し、
+/// 呼び出し側（[`read_style`]）が
+/// [`ReadStyleError::MultipleValidationErrors`] へ集約します。`csl_path` / `locale_path` を独立に
+/// 試すため、1 度の実行で双方の不備をまとめて報告できます。`None` のフィールドは何もしません。
+fn resolve_reference_paths(reference: &mut ReferenceStyle) -> Vec<ValidationError> {
+  let mut errors: Vec<ValidationError> = Vec::new();
+
+  if let Some(path) = reference.csl_path.take() {
+    match path.canonicalize() {
+      Ok(canonical) => reference.csl_path = Some(canonical),
+      Err(source) => errors.push(ValidationError::CslPathResolution {
+        path: path.display().to_string(),
+        source,
+      }),
+    }
+  }
+
+  if let Some(path) = reference.locale_path.take() {
+    match path.canonicalize() {
+      Ok(canonical) => reference.locale_path = Some(canonical),
+      Err(source) => errors.push(ValidationError::LocalePathResolution {
+        path: path.display().to_string(),
+        source,
+      }),
+    }
+  }
+
+  return errors;
+}
+
+#[cfg(test)]
+mod tests {
+  use std::path::PathBuf;
+
+  use tempfile::NamedTempFile;
+
+  use crate::{ReferenceStyle, ValidationError, resolve_reference_paths};
+
+  #[test]
+  fn resolve_reference_paths_makes_csl_path_absolute() {
+    // Arrange — 実在する一時ファイルを csl_path に設定
+    let file = NamedTempFile::new().expect("一時ファイルを作成できるはず");
+    let mut reference = ReferenceStyle {
+      csl_path: Some(file.path().to_path_buf()),
+      ..ReferenceStyle::default()
+    };
+
+    // Act
+    let errors = resolve_reference_paths(&mut reference);
+
+    // Assert — 絶対パスへ正規化され、エラーは無い
+    assert!(errors.is_empty(), "実在パスはエラーにならないはず: {errors:?}");
+    assert!(reference.csl_path.expect("csl_path は残るはず").is_absolute());
+  }
+
+  #[test]
+  fn resolve_reference_paths_reports_missing_files() {
+    // Arrange — 実在しない csl_path / locale_path
+    let mut reference = ReferenceStyle {
+      csl_path: Some(PathBuf::from("/nonexistent/style.csl")),
+      locale_path: Some(PathBuf::from("/nonexistent/locale.xml")),
+      ..ReferenceStyle::default()
+    };
+
+    // Act — 双方の不備をまとめて報告する
+    let errors = resolve_reference_paths(&mut reference);
+
+    // Assert
+    assert_eq!(errors.len(), 2, "csl_path / locale_path 双方が報告されるはず: {errors:?}");
+    assert!(errors.iter().any(|e| matches!(e, ValidationError::CslPathResolution { .. })));
+    assert!(errors.iter().any(|e| matches!(e, ValidationError::LocalePathResolution { .. })));
+  }
+
+  #[test]
+  fn resolve_reference_paths_skips_none() {
+    // Arrange / Act / Assert — 既定（csl_path / locale_path ともに None）なら何もしない
+    let mut reference = ReferenceStyle::default();
+    let errors = resolve_reference_paths(&mut reference);
+    assert!(errors.is_empty());
+  }
 }

--- a/crates/read_style/src/list.rs
+++ b/crates/read_style/src/list.rs
@@ -23,7 +23,7 @@ pub struct ListStyle {
   pub unordered_marker: String,
   /// 順序付きリストのマーカー書式（例: `"{number}."`）。`{number}` は 1 始まりの項目番号で置換される。
   /// 後ろに自動で半角スペースが付与される。
-  #[garde(length(chars, min = 1))]
+  #[garde(length(chars, min = 1), custom(crate::placeholder::ordered_list_format))]
   pub ordered_format: String,
   /// マーカー描画に使用するフォント種別
   pub marker_font_kind: FontKind,

--- a/crates/read_style/src/placeholder.rs
+++ b/crates/read_style/src/placeholder.rs
@@ -1,0 +1,317 @@
+//! フォーマットテンプレート文字列中の `{name}` プレースホルダを検証する共通ロジック。
+//!
+//! `style.toml` の見出し・カウンタ・キャプション・数式番号・定理・リスト・走り文
+//! （header / footer）の各テンプレート文字列は、消費側（`lowering` / `layout` / `parser`）が
+//! `str::replace("{number}", …)` 方式で実体に置換する。置換対象に無い名前を書いても無言で
+//! 素通りし、`{nubmer}` のようなタイポがそのまま誌面に出てしまう。
+//!
+//! 本モジュールは設定読込時にプレースホルダ名を文脈ごとの許可セットと照合し、未知の名前や
+//! 不正な波括弧構文（未閉じ・空・ネスト・孤立 `}`）を [`garde::Error`] として報告する。各
+//! フィールドのバリデーターは `#[garde(custom(crate::placeholder::…))]` から参照され、検出された
+//! エラーは既存の `validate_values` 経由で [`crate::ReadStyleError::MultipleValidationErrors`] に
+//! 集約される。
+//!
+//! 波括弧 `{` `}` はプレースホルダ専用とし、リテラルの波括弧やエスケープ（`{{`）は現状サポート
+//! しない（将来導入する場合も本モジュールの仕様変更として扱う）。
+
+use crate::counter::CounterName;
+
+/// 見出し書式（`heading.<level>.format`）で許可するプレースホルダ。
+const HEADING: &[&str] = &["number", "title"];
+
+/// キャプション書式（`figure.caption.format` / `table.caption.format`）で許可するプレースホルダ。
+const CAPTION: &[&str] = &["number", "title"];
+
+/// 数式番号書式（`equation.number_format`）で許可するプレースホルダ。
+const EQUATION_NUMBER: &[&str] = &["number"];
+
+/// 順序付きリストのマーカー書式（`list.ordered_format`）で許可するプレースホルダ。
+const ORDERED_LIST: &[&str] = &["number"];
+
+/// カウンタの参照書式（`counters.<name>.ref_format`）で許可するプレースホルダ。
+const REF_FORMAT: &[&str] = &["number", "display_name"];
+
+/// 定理の見出し書式（`theorems.<class>.style.heading_*`）で許可するプレースホルダ。
+const THEOREM_HEADING: &[&str] = &["display_name", "number", "title", "of"];
+
+/// 走り文スロット（`header.{left,center,right}` / `footer.{left,center,right}`）で許可する
+/// プレースホルダ。
+const RUNNING: &[&str] = &["page", "pages", "title", "author", "date"];
+
+/// カウンタ番号書式（`counters.<name>.format` / `theorems.<class>.format`）で許可するプレースホルダ
+/// かどうかを判定する。
+///
+/// `{n}` は「そのカウンタ自身の値」を指す特別トークン、それ以外は固定 9 種の他カウンタ名
+/// （[`CounterName::ALL`]）のみを許可する。
+fn is_counter_placeholder(name: &str) -> bool {
+  return name == "n" || CounterName::ALL.iter().any(|counter| counter.as_str() == name);
+}
+
+/// テンプレート文字列中の `{name}` プレースホルダを走査し、不正を一括検出する。
+///
+/// `is_allowed` がその文脈で妥当なプレースホルダ名を判定するクロージャ。検出した不正は
+/// 途中で打ち切らずに集約し、1 件以上あれば全件を 1 つの [`garde::Error`] にまとめて返す。
+/// 不正の種類は次のとおり:
+///
+/// - 未知のプレースホルダ名（`is_allowed` が `false`）
+/// - 空のプレースホルダ `{}`
+/// - 閉じられていない `{`（文字列終端まで `}` が無い）
+/// - ネストした波括弧（`{` の内側に `{`）
+/// - 対応する `{` の無い孤立した `}`
+///
+/// プレースホルダを含まない文字列（空文字列を含む）は妥当として `Ok(())` を返す。空文字列自体の
+/// 可否は呼び出し側の `length` ルールが別途決める。
+fn check_placeholders(template: &str, is_allowed: impl Fn(&str) -> bool) -> garde::Result {
+  let mut problems: Vec<String> = Vec::new();
+  let mut chars = template.chars().peekable();
+
+  while let Some(c) = chars.next() {
+    match c {
+      '{' => {
+        // 対応する '}' まで名前を読み取る。途中で '{' が再出現したらネストとして扱う。
+        let mut name = String::new();
+        let mut closed = false;
+        let mut nested = false;
+        while let Some(&next) = chars.peek() {
+          if next == '}' {
+            chars.next();
+            closed = true;
+            break;
+          }
+          if next == '{' {
+            nested = true;
+            break;
+          }
+          name.push(next);
+          chars.next();
+        }
+
+        if nested {
+          // 内側の '{' は外側ループが改めて処理する（そこでも未閉じ等として検出される）。
+          problems.push("プレースホルダがネストしています（'{' の内側に '{' があります）".to_string());
+          continue;
+        }
+        if !closed {
+          problems.push("閉じられていない '{' があります".to_string());
+          // 以降は構文として解釈できないため走査を打ち切る。
+          break;
+        }
+        if name.is_empty() {
+          problems.push("空のプレースホルダ '{}' があります".to_string());
+        } else if !is_allowed(&name) {
+          problems.push(format!("未知のプレースホルダ '{{{name}}}' があります"));
+        }
+      },
+      '}' => problems.push("対応する '{' のない '}' があります".to_string()),
+      _ => {},
+    }
+  }
+
+  if problems.is_empty() {
+    return Ok(());
+  }
+  return Err(garde::Error::new(problems.join("; ")));
+}
+
+/// 見出し書式（`heading.<level>.format`）用の `garde` カスタムバリデーター。
+///
+/// # Errors
+///
+/// 未知のプレースホルダまたは不正な波括弧構文を含む場合に [`garde::Error`] を返す。
+#[allow(clippy::trivially_copy_pass_by_ref)]
+pub(crate) fn heading_format(value: &str, _: &()) -> garde::Result {
+  return check_placeholders(value, |name| HEADING.contains(&name));
+}
+
+/// キャプション書式（`figure.caption.format` / `table.caption.format`）用のバリデーター。
+///
+/// # Errors
+///
+/// 未知のプレースホルダまたは不正な波括弧構文を含む場合に [`garde::Error`] を返す。
+#[allow(clippy::trivially_copy_pass_by_ref)]
+pub(crate) fn caption_format(value: &str, _: &()) -> garde::Result {
+  return check_placeholders(value, |name| CAPTION.contains(&name));
+}
+
+/// 数式番号書式（`equation.number_format`）用のバリデーター。
+///
+/// # Errors
+///
+/// 未知のプレースホルダまたは不正な波括弧構文を含む場合に [`garde::Error`] を返す。
+#[allow(clippy::trivially_copy_pass_by_ref)]
+pub(crate) fn equation_number_format(value: &str, _: &()) -> garde::Result {
+  return check_placeholders(value, |name| EQUATION_NUMBER.contains(&name));
+}
+
+/// 順序付きリストのマーカー書式（`list.ordered_format`）用のバリデーター。
+///
+/// # Errors
+///
+/// 未知のプレースホルダまたは不正な波括弧構文を含む場合に [`garde::Error`] を返す。
+#[allow(clippy::trivially_copy_pass_by_ref)]
+pub(crate) fn ordered_list_format(value: &str, _: &()) -> garde::Result {
+  return check_placeholders(value, |name| ORDERED_LIST.contains(&name));
+}
+
+/// カウンタ番号書式（`counters.<name>.format` / `theorems.<class>.format`）用のバリデーター。
+///
+/// `{n}`（自身）と固定 9 種の他カウンタ名のみを許可する。
+///
+/// # Errors
+///
+/// 未知のプレースホルダまたは不正な波括弧構文を含む場合に [`garde::Error`] を返す。
+#[allow(clippy::trivially_copy_pass_by_ref)]
+pub(crate) fn counter_format(value: &str, _: &()) -> garde::Result {
+  return check_placeholders(value, is_counter_placeholder);
+}
+
+/// カウンタの参照書式（`counters.<name>.ref_format`）用のバリデーター。
+///
+/// # Errors
+///
+/// 未知のプレースホルダまたは不正な波括弧構文を含む場合に [`garde::Error`] を返す。
+#[allow(clippy::trivially_copy_pass_by_ref)]
+pub(crate) fn ref_format(value: &str, _: &()) -> garde::Result {
+  return check_placeholders(value, |name| REF_FORMAT.contains(&name));
+}
+
+/// 定理の見出し書式（`theorems.<class>.style.heading_*` の 4 フィールド）用のバリデーター。
+///
+/// 検証は構造的妥当性のみで、意味的妥当性（`heading_format` に `{of}` を書く等）は問わない。
+///
+/// # Errors
+///
+/// 未知のプレースホルダまたは不正な波括弧構文を含む場合に [`garde::Error`] を返す。
+#[allow(clippy::trivially_copy_pass_by_ref)]
+pub(crate) fn theorem_heading_format(value: &str, _: &()) -> garde::Result {
+  return check_placeholders(value, |name| THEOREM_HEADING.contains(&name));
+}
+
+/// 走り文スロット（`header` / `footer` の左中右）用のバリデーター。
+///
+/// 空文字列（描画なし）は妥当として許可する。
+///
+/// # Errors
+///
+/// 未知のプレースホルダまたは不正な波括弧構文を含む場合に [`garde::Error`] を返す。
+#[allow(clippy::trivially_copy_pass_by_ref)]
+pub(crate) fn running_slot(value: &str, _: &()) -> garde::Result {
+  return check_placeholders(value, |name| RUNNING.contains(&name));
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{
+    CounterName, caption_format, check_placeholders, counter_format, equation_number_format, heading_format,
+    is_counter_placeholder, ordered_list_format, ref_format, running_slot, theorem_heading_format,
+  };
+
+  /// 全プレースホルダを許可するクロージャ（構文系のみを試すテスト用）。
+  fn allow_all(_: &str) -> bool { return true; }
+
+  /// 何も許可しないクロージャ（未知名検出を試すテスト用）。
+  fn allow_none(_: &str) -> bool { return false; }
+
+  #[test]
+  fn accepts_literals_and_valid_placeholders() {
+    // Arrange / Act / Assert — リテラルのみ・空文字列・正当なプレースホルダは通る
+    assert!(check_placeholders("", allow_all).is_ok());
+    assert!(check_placeholders("第 章", allow_all).is_ok());
+    assert!(check_placeholders("{number} {title}", |n| ["number", "title"].contains(&n)).is_ok());
+    assert!(check_placeholders("({number})", |n| n == "number").is_ok());
+    assert!(check_placeholders("第{n}章", |n| n == "n").is_ok());
+  }
+
+  #[test]
+  fn rejects_unknown_placeholder() {
+    // Arrange / Act / Assert
+    assert!(check_placeholders("{nubmer}", allow_none).is_err());
+  }
+
+  #[test]
+  fn rejects_unclosed_brace() {
+    // Arrange / Act / Assert
+    assert!(check_placeholders("{number", allow_all).is_err());
+  }
+
+  #[test]
+  fn rejects_empty_placeholder() {
+    // Arrange / Act / Assert
+    assert!(check_placeholders("{}", allow_all).is_err());
+  }
+
+  #[test]
+  fn rejects_nested_braces() {
+    // Arrange / Act / Assert
+    assert!(check_placeholders("{a{b}}", allow_all).is_err());
+  }
+
+  #[test]
+  fn rejects_stray_closing_brace() {
+    // Arrange / Act / Assert
+    assert!(check_placeholders("x}y", allow_all).is_err());
+  }
+
+  #[test]
+  fn reports_multiple_unknown_placeholders_together() {
+    // Arrange / Act — 2 つの未知名を含む
+    let result = check_placeholders("{a} {b}", allow_none);
+
+    // Assert — 1 つのエラーに両名が列挙される
+    let message = result.expect_err("未知名 2 件はエラーになるはず").to_string();
+    assert!(message.contains("{a}"), "メッセージに {{a}} を含むべき: {message}");
+    assert!(message.contains("{b}"), "メッセージに {{b}} を含むべき: {message}");
+  }
+
+  #[test]
+  fn is_counter_placeholder_accepts_self_and_nine_counters() {
+    // Arrange / Act / Assert — {n}（自身）と固定 9 種を許可
+    assert!(is_counter_placeholder("n"));
+    for counter in CounterName::ALL {
+      assert!(is_counter_placeholder(counter.as_str()), "{} は許可されるべき", counter.as_str());
+    }
+    assert!(!is_counter_placeholder("foo"));
+  }
+
+  #[test]
+  fn counter_format_accepts_all_counter_references() {
+    // Arrange — 9 カウンタ名 + {n} をすべて含むテンプレート
+    let template: String = std::iter::once("{n}".to_string())
+      .chain(CounterName::ALL.iter().map(|c| format!("{{{}}}", c.as_str())))
+      .collect();
+
+    // Act / Assert
+    assert!(counter_format(&template, &()).is_ok());
+    assert!(counter_format("{foo}", &()).is_err());
+  }
+
+  #[test]
+  fn field_validators_accept_their_tokens() {
+    // Arrange / Act / Assert — 各フィールドの代表的な正当値
+    assert!(heading_format("{number} {title}", &()).is_ok());
+    assert!(caption_format("Figure {number}: {title}", &()).is_ok());
+    assert!(equation_number_format("({number})", &()).is_ok());
+    assert!(ordered_list_format("{number}.", &()).is_ok());
+    assert!(ref_format("{display_name} {number}", &()).is_ok());
+    assert!(theorem_heading_format("{display_name} of {of} ({title})", &()).is_ok());
+  }
+
+  #[test]
+  fn field_validators_reject_foreign_tokens() {
+    // Arrange / Act / Assert — 文脈に無いトークンは弾く
+    assert!(heading_format("{display_name}", &()).is_err());
+    assert!(equation_number_format("{title}", &()).is_err());
+    assert!(ordered_list_format("{title}", &()).is_err());
+    assert!(ref_format("{title}", &()).is_err());
+    assert!(theorem_heading_format("{page}", &()).is_err());
+  }
+
+  #[test]
+  fn running_slot_accepts_empty_and_five_tokens() {
+    // Arrange / Act / Assert — 空（描画なし）と 5 トークンは通り、タイポは弾く
+    assert!(running_slot("", &()).is_ok());
+    assert!(running_slot("{page} / {pages}", &()).is_ok());
+    assert!(running_slot("{title} — {author} ({date})", &()).is_ok());
+    assert!(running_slot("{pagee}", &()).is_err());
+  }
+}

--- a/crates/read_style/src/reference.rs
+++ b/crates/read_style/src/reference.rs
@@ -24,8 +24,9 @@ pub struct ReferenceStyle {
   /// IEEE / APA などの整形規則（採番方式・書誌の体裁）を定める独立 CSL スタイル
   /// （independent style）を指す。引用の見た目を決める設定なので style.toml に置く。
   /// `None`（既定）で引用（`\cite`）が存在する場合は `citation` がエラーを報告する。
-  /// パスの読み込み・解析は `locale_path` と同様に `citation` クレートが [`crate::read_style`]
-  /// 後に実施する（`read_style` では検証・正規化しない）。
+  /// パスは [`read_style`](crate::read_style) が `canonicalize` で絶対パスへ正規化し、同時に
+  /// ファイルの存在を検証する（解決できなければ [`crate::ValidationError::CslPathResolution`]）。
+  /// ファイル内容の読み込み・解析（CSL スタイルのパース）は `citation` クレートが後段で行う。
   #[garde(skip)]
   pub csl_path: Option<PathBuf>,
   /// 引用整形に用いる CSL ロケールファイル（`.xml`）のパス。
@@ -35,7 +36,9 @@ pub struct ReferenceStyle {
   /// 同一言語コードのロケールは内蔵より優先される。`None`（既定）の場合は内蔵ロケールのみを使う。
   /// なお書誌の出力言語（active locale）は [`locale`](Self::locale) で決まり、`locale` が未指定の
   /// ときに限り、本ファイルの `xml:lang` がその既定値として採用される。
-  /// パスの読み込み・解析は `citation` クレートが [`crate::read_style`] 後に実施する。
+  /// パスは [`read_style`](crate::read_style) が `canonicalize` で絶対パスへ正規化し、ファイルの
+  /// 存在を検証する（解決できなければ [`crate::ValidationError::LocalePathResolution`]）。
+  /// ファイル内容の読み込み・解析（ロケール XML のパース）は `citation` クレートが後段で行う。
   #[garde(skip)]
   pub locale_path: Option<PathBuf>,
   /// 書誌の出力言語（CSL の active locale）を選ぶロケールコード（例 `"ja-JP"`）。
@@ -44,9 +47,11 @@ pub struct ReferenceStyle {
   /// [`locale_path`](Self::locale_path) のファイルは不要で、本フィールドの指定だけで足りる。
   /// active locale は次の優先順位で決まる: 本フィールド → [`locale_path`](Self::locale_path) の
   /// ファイルの `xml:lang` → `.csl` の `default-locale`（最終的に en-US）。`citation` クレートが
-  /// `BibliographyRequest` / `CitationRequest` の locale override として解釈する
-  /// （`read_style` では検証・正規化しない）。
-  #[garde(skip)]
+  /// `BibliographyRequest` / `CitationRequest` の locale override として解釈する。
+  /// [`read_style`](crate::read_style) がロケールコードの構文を検証し（不正なら
+  /// [`crate::ValidationError::Field`]）、大文字小文字を BCP 47 の標準形へ正規化する
+  /// （例 `ja-jp` → `ja-JP`。言語=小文字・地域=大文字・用字=先頭大文字）。
+  #[garde(custom(validate_locale))]
   pub locale: Option<String>,
 }
 
@@ -61,6 +66,92 @@ impl Default for ReferenceStyle {
       locale: None,
     };
   }
+}
+
+impl ReferenceStyle {
+  /// 値を正規化する（現状はロケールコードの大文字小文字を BCP 47 の標準形へ揃える）。
+  ///
+  /// [`crate::parse_style`] が値検証の後に呼び出す純粋処理。`locale` が `Some` のとき、言語サブ
+  /// タグを小文字・地域サブタグを大文字・用字サブタグを先頭大文字へ整える（例 `ja-jp` → `ja-JP`）。
+  /// `citation` の内蔵ロケール照合は文字列一致のため、ここで標準形へ揃えておくと照合が安定する。
+  /// `None` のときは何もしない。パスの正規化（`canonicalize`）は I/O を伴うため [`crate::read_style`]
+  /// 側で行う。
+  pub fn normalize(&mut self) {
+    if let Some(code) = &self.locale {
+      self.locale = Some(normalize_locale_code(code));
+    }
+  }
+}
+
+/// ロケールコードの構文を検証する `garde` カスタムバリデーター。
+///
+/// `None`（ロケール未指定）は許可する。`Some` のときは BCP 47 風の構文（言語サブタグ + 任意の
+/// サブタグ）に合致するかだけを確認し、大文字小文字は問わない（[`normalize_locale_code`] が後段で
+/// 標準形へ揃える）。実在するロケールかどうかは検証しない（内蔵 / カスタムロケールの有無は
+/// `citation` が解決する）。
+#[allow(clippy::ref_option, clippy::trivially_copy_pass_by_ref)]
+fn validate_locale(value: &Option<String>, _: &()) -> garde::Result {
+  let Some(code) = value else {
+    return Ok(());
+  };
+  if !is_well_formed_locale(code) {
+    return Err(garde::Error::new(format!(
+      "ロケールコードの構文が不正です（例: \"ja-JP\"・\"en\"）（受け取った値: {code:?}）"
+    )));
+  }
+  return Ok(());
+}
+
+/// ロケールコードが BCP 47 風の構文に合致するかを判定する。
+///
+/// 先頭サブタグ（言語）は 2〜3 文字の ASCII 英字、後続サブタグは 1〜8 文字の ASCII 英数字とし、
+/// ハイフン区切りで空サブタグを含まないことを要求する。実在性は検証しない。
+fn is_well_formed_locale(code: &str) -> bool {
+  let mut subtags = code.split('-');
+  let Some(language) = subtags.next() else {
+    return false;
+  };
+  if !(2..=3).contains(&language.len()) || !language.bytes().all(|b| b.is_ascii_alphabetic()) {
+    return false;
+  }
+  for subtag in subtags {
+    if !(1..=8).contains(&subtag.len()) || !subtag.bytes().all(|b| b.is_ascii_alphanumeric()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/// ロケールコードを BCP 47 の標準形（言語=小文字 / 用字=先頭大文字 / 地域=大文字）へ正規化する。
+///
+/// 構文が [`is_well_formed_locale`] を満たす前提で、各サブタグの大文字小文字だけを整える。
+/// - 言語（先頭サブタグ）: 小文字（例 `JA` → `ja`）
+/// - 用字（4 文字英字）: 先頭大文字 + 残り小文字（例 `hant` → `Hant`）
+/// - 地域（2 文字英字）: 大文字（例 `jp` → `JP`）
+/// - それ以外（3 桁地域コード・variant 等）: そのまま
+fn normalize_locale_code(code: &str) -> String {
+  let mut out = String::with_capacity(code.len());
+  for (index, subtag) in code.split('-').enumerate() {
+    if index > 0 {
+      out.push('-');
+    }
+    if index == 0 {
+      out.extend(subtag.chars().map(|c| c.to_ascii_lowercase()));
+    } else if subtag.len() == 4 && subtag.bytes().all(|b| b.is_ascii_alphabetic()) {
+      out.extend(subtag.chars().enumerate().map(|(i, c)| {
+        if i == 0 {
+          c.to_ascii_uppercase()
+        } else {
+          c.to_ascii_lowercase()
+        }
+      }));
+    } else if subtag.len() == 2 && subtag.bytes().all(|b| b.is_ascii_alphabetic()) {
+      out.extend(subtag.chars().map(|c| c.to_ascii_uppercase()));
+    } else {
+      out.push_str(subtag);
+    }
+  }
+  return out;
 }
 
 #[cfg(test)]
@@ -113,5 +204,77 @@ mod tests {
     assert_eq!(style.reference.csl_path, Some(PathBuf::from("styles/ieee.csl")));
     assert_eq!(style.reference.locale_path, Some(PathBuf::from("locales/locales-ja-JP.xml")));
     assert_eq!(style.reference.locale.as_deref(), Some("ja-JP"));
+  }
+
+  #[test]
+  fn validate_accepts_well_formed_locale() {
+    // Arrange / Act / Assert — 言語のみ・言語-地域・言語-用字 はいずれも許可
+    for code in ["en", "ja-JP", "zh-Hant", "es-419"] {
+      let style = ReferenceStyle {
+        locale: Some(code.to_string()),
+        ..ReferenceStyle::default()
+      };
+      assert!(style.validate().is_ok(), "{code:?} は妥当なロケールとして許可されるべき");
+    }
+  }
+
+  #[test]
+  fn validate_accepts_locale_regardless_of_case() {
+    // 大文字小文字は問わない（正規化が後段で標準形へ揃える）
+    let style = ReferenceStyle {
+      locale: Some("ja-jp".to_string()),
+      ..ReferenceStyle::default()
+    };
+    assert!(style.validate().is_ok());
+  }
+
+  #[test]
+  fn validate_rejects_malformed_locale() {
+    // Arrange / Act / Assert — 空・短すぎる言語・アンダースコア・空サブタグ・非英数字
+    for bad in ["", "j", "ja_JP", "ja-", "ja JP", "english"] {
+      let style = ReferenceStyle {
+        locale: Some(bad.to_string()),
+        ..ReferenceStyle::default()
+      };
+      assert!(style.validate().is_err(), "{bad:?} は不正なロケールとして拒否されるべき");
+    }
+  }
+
+  #[test]
+  fn normalize_canonicalizes_locale_case() {
+    // Arrange
+    let mut style = ReferenceStyle {
+      locale: Some("EN-us".to_string()),
+      ..ReferenceStyle::default()
+    };
+
+    // Act
+    style.normalize();
+
+    // Assert — 言語=小文字・地域=大文字へ揃う
+    assert_eq!(style.locale.as_deref(), Some("en-US"));
+  }
+
+  #[test]
+  fn normalize_canonicalizes_script_subtag() {
+    // Arrange — 用字サブタグ（4 文字）は先頭大文字 + 残り小文字
+    let mut style = ReferenceStyle {
+      locale: Some("zh-HANT".to_string()),
+      ..ReferenceStyle::default()
+    };
+
+    // Act
+    style.normalize();
+
+    // Assert
+    assert_eq!(style.locale.as_deref(), Some("zh-Hant"));
+  }
+
+  #[test]
+  fn normalize_keeps_none_locale() {
+    // Arrange / Act / Assert — locale が None なら何もしない
+    let mut style = ReferenceStyle::default();
+    style.normalize();
+    assert!(style.locale.is_none());
   }
 }

--- a/crates/read_style/src/running.rs
+++ b/crates/read_style/src/running.rs
@@ -30,13 +30,13 @@ use types::{
 #[serde(deny_unknown_fields, default)]
 pub struct RunningContentStyle {
   /// 左スロットのテンプレート（既定は空 = 描画なし）
-  #[garde(skip)]
+  #[garde(custom(crate::placeholder::running_slot))]
   pub left: String,
   /// 中央スロットのテンプレート（既定は空 = 描画なし）
-  #[garde(skip)]
+  #[garde(custom(crate::placeholder::running_slot))]
   pub center: String,
   /// 右スロットのテンプレート（既定は空 = 描画なし）
-  #[garde(skip)]
+  #[garde(custom(crate::placeholder::running_slot))]
   pub right: String,
   /// フォント種別
   #[garde(skip)]
@@ -142,6 +142,32 @@ mod tests {
 
     // Act / Assert
     assert!(style.validate().is_err());
+  }
+
+  #[test]
+  fn validate_rejects_unknown_slot_token() {
+    // Arrange: `{page}` のタイポ `{pagee}` を center スロットに
+    let style = RunningContentStyle {
+      center: "{pagee}".to_string(),
+      ..RunningContentStyle::default()
+    };
+
+    // Act / Assert
+    assert!(style.validate().is_err());
+  }
+
+  #[test]
+  fn validate_accepts_valid_slot_tokens() {
+    // Arrange: 5 トークンと空スロットの混在は妥当
+    let style = RunningContentStyle {
+      left: "{title}".to_string(),
+      center: "{author}".to_string(),
+      right: "{page} / {pages} — {date}".to_string(),
+      ..RunningContentStyle::default()
+    };
+
+    // Act / Assert
+    assert!(style.validate().is_ok());
   }
 
   #[test]

--- a/crates/read_style/src/theorem.rs
+++ b/crates/read_style/src/theorem.rs
@@ -117,7 +117,7 @@ pub struct TheoremStyle {
   pub reset_by: TheoremReset,
   /// 番号テンプレート。`{n}` で自身、`{<counter_name>}` で他カウンタの値を埋め込む
   /// （counter の `format` と同形。例: `"{n}"`、`"{chapter}.{n}"`）
-  #[garde(length(chars, min = 1))]
+  #[garde(length(chars, min = 1), custom(crate::placeholder::counter_format))]
   pub format: String,
   /// 採番しない（`proof` 等）。`true` のとき番号は付かない
   pub unnumbered: bool,
@@ -174,23 +174,23 @@ pub enum TheoremReset {
 #[serde(deny_unknown_fields, default)]
 pub struct TheoremPresentation {
   /// サブタイトルなしの見出し書式。`{display_name}` と `{number}` を含められる
-  #[garde(length(chars, min = 1))]
+  #[garde(length(chars, min = 1), custom(crate::placeholder::theorem_heading_format))]
   pub heading_format: String,
   /// サブタイトルありの見出し書式。`{display_name}` / `{number}` / `{title}` を含められる
-  #[garde(length(chars, min = 1))]
+  #[garde(length(chars, min = 1), custom(crate::placeholder::theorem_heading_format))]
   pub heading_with_title: String,
   /// 証明対象（`of`）ありサブタイトルなしの見出し書式。`{display_name}` / `{of}` を含められる。
   ///
   /// `proof` の `[of=...]` 指定時にのみ選択される（`{of}` は対象定理の cleveref 文字列
   /// ＝「Theorem 1」等に解決される）。前置語「of」を含む結合書式ごとこのフィールドで上書きでき、
   /// 国際化（`{display_name}（{of} の証明）` 等）も可能。`proof` 以外のクラスでは `of` を取れないため未使用。
-  #[garde(length(chars, min = 1))]
+  #[garde(length(chars, min = 1), custom(crate::placeholder::theorem_heading_format))]
   pub heading_with_of: String,
   /// 証明対象（`of`）ありサブタイトルありの見出し書式。`{display_name}` / `{of}` / `{title}` を含められる。
   ///
   /// `of` と `title` を併用したときの結合書式。既定は `of` を先に、`title` を括弧で後置する
   /// （「Proof of Theorem 1 (…)」）。
-  #[garde(length(chars, min = 1))]
+  #[garde(length(chars, min = 1), custom(crate::placeholder::theorem_heading_format))]
   pub heading_with_of_and_title: String,
   /// 本文のフォント種別（定理は斜体、証明・定義系はローマン）
   pub font_kind: FontKind,
@@ -478,6 +478,28 @@ mod tests {
     // Arrange: Some("") は inner 検証で弾かれる
     let style = TheoremStyle {
       qed_mark: Some(String::new()),
+      ..TheoremStyle::default()
+    };
+
+    // Act / Assert
+    assert!(style.validate().is_err());
+  }
+
+  #[test]
+  fn validate_rejects_unknown_heading_placeholder() {
+    // Arrange: 見出し書式に許可外トークン `{page}` を入れる
+    let mut style = TheoremStyle::default();
+    style.style.heading_format = "{page}".to_string();
+
+    // Act / Assert
+    assert!(style.validate().is_err());
+  }
+
+  #[test]
+  fn validate_rejects_unknown_counter_reference_in_format() {
+    // Arrange: format（カウンタ規則）に未知のカウンタ参照 `{chaptr}`
+    let style = TheoremStyle {
+      format: "{chaptr}.{n}".to_string(),
       ..TheoremStyle::default()
     };
 

--- a/crates/read_style/tests/validate.rs
+++ b/crates/read_style/tests/validate.rs
@@ -18,7 +18,9 @@ fn paths(errors: &[ValidationError]) -> Vec<&str> {
   return errors
     .iter()
     .map(|error| match error {
-      ValidationError::Field { path, .. } => path.as_str(),
+      ValidationError::Field { path, .. }
+      | ValidationError::CslPathResolution { path, .. }
+      | ValidationError::LocalePathResolution { path, .. } => path.as_str(),
     })
     .collect();
 }
@@ -86,6 +88,67 @@ resets = []
     matches!(result, Err(ReadStyleError::ParseToml { .. })),
     "unknown counter name should be rejected at TOML parse time, got {result:?}"
   );
+}
+
+#[test]
+fn empty_toml_defaults_pass_placeholder_validation() {
+  // Arrange / Act — 空 TOML は全フィールドが既定値。新しいプレースホルダ検証を通るはず
+  let result = parse_style("", dummy_source());
+
+  // Assert
+  assert!(result.is_ok(), "既定値はプレースホルダ検証を通るべき: {result:?}");
+}
+
+#[test]
+fn reports_unknown_placeholders_across_fields_together() {
+  // Arrange: 見出し書式と footer スロットの双方にタイポを入れる
+  let toml = "
+[heading.section]
+format = \"{nubmer} {title}\"
+
+[footer]
+center = \"{pagee}\"
+";
+
+  // Act — 1 度の実行で両方の不正が報告される
+  let errors = expect_validation_errors(parse_style(toml, dummy_source()));
+
+  // Assert
+  let paths = paths(&errors);
+  assert!(paths.contains(&"heading.section.format"), "expected heading.section.format in {paths:?}");
+  assert!(paths.contains(&"footer.center"), "expected footer.center in {paths:?}");
+}
+
+#[test]
+fn placeholder_error_message_names_the_offending_token() {
+  // Arrange: equation.number_format に未知プレースホルダ {num}
+  let toml = "[equation]\nnumber_format = \"({num})\"\n";
+
+  // Act
+  let errors = expect_validation_errors(parse_style(toml, dummy_source()));
+
+  // Assert: メッセージに不正なプレースホルダ名が含まれる
+  let message = errors
+    .iter()
+    .find_map(|error| match error {
+      ValidationError::Field { path, message } if path == "equation.number_format" => Some(message.as_str()),
+      _ => None,
+    })
+    .expect("equation.number_format のエラーがあるはず");
+  assert!(message.contains("{num}"), "メッセージに {{num}} を含むべき: {message}");
+}
+
+#[test]
+fn rejects_unknown_counter_placeholder_in_format() {
+  // Arrange: counters.section.format に未知のカウンタ参照 {chaptr}（chapter のタイポ）
+  let toml = "[counters.section]\ndisplay_name = \"Section\"\nformat = \"{chaptr}.{n}\"\nnumber_style = \"arabic\"\nref_format = \"{display_name} {number}\"\nresets = []\n";
+
+  // Act
+  let errors = expect_validation_errors(parse_style(toml, dummy_source()));
+
+  // Assert
+  let paths = paths(&errors);
+  assert!(paths.contains(&"counters.section.format"), "expected counters.section.format in {paths:?}");
 }
 
 #[test]


### PR DESCRIPTION
## 概要

`style.toml` のフォーマットテンプレートと走り文（header/footer）の各トークンについて、未知のプレースホルダと不正な波括弧構文を設定読込時に検証して弾く。タイポ（`{nubmer}` 等）が無言で素通りして壊れた PDF になる問題を、設計方針（LaTeX の曖昧さ排除・未知は弾く）に沿って解消する。あわせて、作業中だった `csl_path`/`locale_path` の正規化とロケールコードの検証/正規化を同梱する。

## 変更内容

### プレースホルダ検証（#99 本体・`crates/read_style`）

- 新規 `placeholder` モジュール: スキャナ `check_placeholders(template, is_allowed)` が `{name}` トークンを走査し、未知名・空 `{}`・未閉じ `{`・ネスト `{a{b}}`・孤立 `}` を一括検出して 1 つの `garde::Error` にまとめる。文脈別の許可セットを持つ 8 個の `garde` カスタムバリデーターがこれを包む。
- 各テンプレートフィールドに `#[garde(custom(...))]` を付与（既存の `length` と併記）:
  - `heading.<level>.format`・`figure/table caption.format` → `{number} {title}`
  - `equation.number_format`・`list.ordered_format` → `{number}`
  - `counters.<name>.format`・`theorems.<class>.format` → `{n}` ＋固定 9 カウンタ名
  - `counters.<name>.ref_format` → `{number} {display_name}`
  - `theorems.<class>.style.heading_*`（4 種）→ `{display_name} {number} {title} {of}`
  - `header`/`footer` の `{left,center,right}`（旧 `skip`）→ `{page} {pages} {title} {author} {date}`（空文字列は描画なしとして許可）
- `CounterName::ALL` を追加（9 カウンタ名の単一ソース）。
- 検出は既存の `validate_values` → `MultipleValidationErrors` 集約にそのまま乗るため、フィールドパス（例 `theorems.theorem.style.heading_format`）は自動構築。`error.rs` の変更は不要。

### 同梱: `csl_path`/`locale_path` 正規化・ロケール検証（別作業）

- `read_style` が `csl_path`/`locale_path` を `canonicalize` で絶対パス化＋存在検証（`CslPathResolution`/`LocalePathResolution`）。
- `reference.locale` の BCP 47 風構文検証（`validate_locale`）と大文字小文字の標準形正規化（`normalize`、例 `ja-jp` → `ja-JP`）。

## 設計上の判断

- `theorems.<class>.format` は issue の表では見出し系トークンと記載されていたが、実コードでは**カウンタ型テンプレート**（`{n}` ＋カウンタ名、既定 `{n}`）。表より実態を優先し、カウンタ規則で検証。見出し書式は別フィールド `theorems.<class>.style.heading_*` の 4 つで `{display_name} {number} {title} {of}` を許可。
- 波括弧 `{` `}` はプレースホルダ専用（リテラル波括弧・`{{` エスケープは不可、将来導入は仕様変更扱い）。未閉じ・空・ネスト・孤立 `}` はすべてエラー。
- バリデーターは `&str` シグネチャ（garde が渡す `&String` から関数引数位置の deref 強制で受かる）。garde 必須の `_: &()` 引数には既存 `validate_locale` に倣い `#[allow(clippy::trivially_copy_pass_by_ref)]` を付与。
- `{n}`（カウンタ自身の生値）と `{number}`（組み立て済みの番号文字列）の二本立て命名の整理は #100 に切り出し。本 PR は現状の振る舞いをそのまま検証に反映するに留める。

## テスト

- `placeholder` 単体（スキャナの各エッジケース・各バリデーター・`{n}`＋9 カウンタ名・空/5 トークンの走り文）。
- 構造体レベル（`heading` / `running` / `theorem` の `.validate()` が typo を弾く）。
- 統合（`tests/validate.rs`）: 複数フィールド横断の一括報告・エラーメッセージに不正トークン名を含む・空 TOML（全既定値）がリグレッションなく通る。
- `cargo test` 全 38 binary green / `cargo clippy` clean / `cargo +nightly fmt` 済み。
- 手動確認: `heading.section.format = "{nubmer} {title}"` ＋ `footer.center = "{pagee}"` で `build` → 設定読込段で両方の不正が `MultipleValidationErrors` としてまとめて報告。既定設定では PDF が従来どおり生成。

## スコープ外

- `{n}` / `{number}` の命名一貫性の決定（#100 で別途）。
- 相対パス解決基準（CWD 基準 vs 設定ファイル位置基準）の見直し。
- プレースホルダの意味拡張（新トークン追加）。

## 関連

- Closes #99
- #100（`{n}` / `{number}` の命名整理）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
