### PR TITLE
ロギング: パイプライン全段のログを網羅・一貫させ、ビルド進捗を可視化する

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+ "tracing",
  "types",
 ]
 
@@ -716,6 +717,7 @@ name = "hlist"
 version = "0.1.0"
 dependencies = [
  "icu",
+ "tracing",
  "types",
 ]
 
@@ -1306,6 +1308,7 @@ dependencies = [
  "icu",
  "lazy-regex",
  "lowering",
+ "tracing",
  "types",
 ]
 
@@ -1377,6 +1380,7 @@ dependencies = [
  "parser",
  "read_style",
  "thiserror",
+ "tracing",
  "types",
 ]
 
@@ -1548,6 +1552,7 @@ dependencies = [
  "serde",
  "syntax",
  "thiserror",
+ "tracing",
  "types",
 ]
 
@@ -1584,6 +1589,7 @@ dependencies = [
  "read_config",
  "read_style",
  "thiserror",
+ "tracing",
  "types",
  "usvg",
 ]
@@ -2226,6 +2232,7 @@ dependencies = [
  "memchr",
  "miette",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/citation/Cargo.toml
+++ b/crates/citation/Cargo.toml
@@ -17,6 +17,7 @@ read_style.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
 types.workspace = true
 
 [dev-dependencies]

--- a/crates/citation/src/lib.rs
+++ b/crates/citation/src/lib.rs
@@ -19,6 +19,7 @@ use miette::Diagnostic;
 use read_references::References;
 use read_style::Style;
 use thiserror::Error;
+use tracing::debug;
 
 mod bridge;
 mod render;
@@ -175,6 +176,7 @@ pub fn process_citations(
 
   let rendered = render::render(&entries, &cite_sites, &csl_style, &locales, locale_override, &style.reference.title);
 
+  let citation_count = cite_nodes.len();
   // ラベルを書き戻す（収集と同じドキュメント順なので zip で対応づく）。
   for (node, label) in cite_nodes.iter_mut().zip(rendered.labels) {
     if let InlineNode::Cite { label: slot, .. } = node {
@@ -184,7 +186,9 @@ pub fn process_citations(
   // 可変借用を解放してから書誌を末尾に追加する。
   drop(cite_nodes);
 
+  let bibliography_count = rendered.bibliography.len();
   nodes.extend(rendered.bibliography);
+  debug!(citation_count, bibliography_count, "文献引用の整形が完了しました");
   return Ok(());
 }
 

--- a/crates/font/src/validate_font.rs
+++ b/crates/font/src/validate_font.rs
@@ -85,7 +85,7 @@ use miette::Diagnostic;
 use read_config::{FontConfig, FontConfigs, VariationAxis};
 use read_fonts::{FontRef, ReadError, TableProvider, tables::layout::ScriptList};
 use thiserror::Error;
-use tracing::{info, warn};
+use tracing::{debug, warn};
 use types::FontType;
 
 use crate::FontRefs;
@@ -196,7 +196,7 @@ pub fn validate_fonts(font_configs: &FontConfigs, font_refs: &FontRefs) -> Resul
     if !errors.is_empty() {
       all_errors.push(FontValidationErrors { font_type, errors });
     }
-    info!(font_type = ?font_type, font_path = %config.font_path.display(), "フォントの検証が完了しました");
+    debug!(font_type = ?font_type, font_path = %config.font_path.display(), "フォントを検証しました");
   }
   if !all_errors.is_empty() {
     return Err(MultipleFontValidationErrors { errors: all_errors });

--- a/crates/hlist/Cargo.toml
+++ b/crates/hlist/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 
 [dependencies]
 icu.workspace = true
+tracing.workspace = true
 types.workspace = true
 
 [lints]

--- a/crates/hlist/src/break_pages.rs
+++ b/crates/hlist/src/break_pages.rs
@@ -10,6 +10,7 @@
 //! ただし画像・表・罫線はブロックの底辺で終わるため、直後の段落はベースラインを
 //! 1 行分のアセント（`line.height`）だけ下げて重なりを防ぐ。
 
+use tracing::debug;
 use types::AnchorMark;
 
 use crate::{
@@ -140,6 +141,7 @@ impl PageComposer {
 #[must_use]
 pub fn break_pages(blocks: Vec<Block>, text_width: f32, geom: &PageGeometry, breaker: &dyn LineBreaker) -> Vec<Page> {
   let mut composer = PageComposer::new(geom);
+  let block_count = blocks.len();
 
   for block in blocks {
     match block {
@@ -224,7 +226,9 @@ pub fn break_pages(blocks: Vec<Block>, text_width: f32, geom: &PageGeometry, bre
     }
   }
 
-  return composer.finish();
+  let pages = composer.finish();
+  debug!(block_count, page_count = pages.len(), "ページ分割が完了しました");
+  return pages;
 }
 
 /// 段落を行に割ってベースライン送りで配置する

--- a/crates/layout/Cargo.toml
+++ b/crates/layout/Cargo.toml
@@ -13,6 +13,7 @@ hlist.workspace = true
 icu.workspace = true
 lazy-regex.workspace = true
 lowering.workspace = true
+tracing.workspace = true
 types.workspace = true
 
 [lints]

--- a/crates/layout/src/lib.rs
+++ b/crates/layout/src/lib.rs
@@ -40,6 +40,7 @@ use lazy_regex::regex_replace_all;
 use lowering::{LayoutNode, TableLayout, TableRowLayout, TextStyle};
 pub use running::{RunningContentSpec, RunningMetadata, RunningSlots, build_running_content};
 pub use toc::{TocEntryInput, TocSpec, build_toc_blocks};
+use tracing::debug;
 use types::{Align, Color, FontKind, FontType, Length};
 
 /// レイアウトノードを計測済みのブロック列に変換する
@@ -64,6 +65,7 @@ pub fn build_blocks(
   let mut paragraph: Vec<HItem> = Vec::new();
   measurer.walk_vertical(layout_nodes, &mut blocks, &mut paragraph, 0.0, Align::Left);
   measurer.flush_paragraph(&mut blocks, &mut paragraph, 0.0, Align::Left);
+  debug!(block_count = blocks.len(), "ブロックの構築が完了しました");
   return blocks;
 }
 

--- a/crates/layout/src/running.rs
+++ b/crates/layout/src/running.rs
@@ -12,6 +12,7 @@
 use font::{FontMetrics, shaper::HarfRustShapers};
 use hlist::{HBox, Line, Page, PlacedBlock, PositionedBox};
 use lowering::TextStyle;
+use tracing::debug;
 use types::FontKind;
 
 use crate::Measurer;
@@ -118,6 +119,7 @@ pub fn build_running_content(
       page.footer = build_region(&mut measurer, slots, spec.text_width, page_label, pages_label, &spec.metadata);
     }
   }
+  debug!(page_count = pages.len(), "ヘッダー・フッターを配置しました");
 }
 
 /// 1 リージョン分の配置済みブロック（行＋任意の区切り線）を組み立てる

--- a/crates/lowering/Cargo.toml
+++ b/crates/lowering/Cargo.toml
@@ -12,6 +12,7 @@ document.workspace = true
 miette.workspace = true
 read_style.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
 types.workspace = true
 
 [dev-dependencies]

--- a/crates/lowering/src/lib.rs
+++ b/crates/lowering/src/lib.rs
@@ -28,6 +28,7 @@ use document::{DocNode, Document};
 use miette::Diagnostic;
 use read_style::Style as ReadStyle;
 use thiserror::Error;
+use tracing::debug;
 
 mod figure;
 mod float;
@@ -175,6 +176,7 @@ pub fn lower_nodes(ctx: &LoweringContext, nodes: &[DocNode]) -> Result<Vec<Layou
       heading_index += 1;
     }
   }
+  debug!(input_node_count = nodes.len(), layout_node_count = result.len(), "lowering が完了しました");
   return Ok(result);
 }
 

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -17,6 +17,7 @@ read_style.workspace = true
 serde.workspace = true
 syntax.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
 types.workspace = true
 
 [lints]

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -25,6 +25,7 @@ use document::DocNode;
 use miette::{Diagnostic, NamedSource};
 pub use read_style::Style;
 use thiserror::Error;
+use tracing::debug;
 
 mod evaluator;
 pub use evaluator::EvalError;
@@ -125,5 +126,6 @@ pub fn parse_source(
     error,
   })?;
 
+  debug!(source_path = source_name, node_count = doc_nodes.len(), "ソースのパース・評価が完了しました");
   return Ok(doc_nodes);
 }

--- a/crates/pdf_gen/Cargo.toml
+++ b/crates/pdf_gen/Cargo.toml
@@ -19,6 +19,7 @@ read_config.workspace = true
 read-fonts.workspace = true
 read_style.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
 types.workspace = true
 usvg.workspace = true
 

--- a/crates/pdf_gen/src/image.rs
+++ b/crates/pdf_gen/src/image.rs
@@ -8,6 +8,7 @@ use std::{fs, path::Path};
 
 use hlist::Block;
 use krilla::image::Image;
+use tracing::debug;
 use usvg::Tree;
 
 use crate::error::PdfGenError;
@@ -24,7 +25,7 @@ use crate::error::PdfGenError;
 /// 画像の読み込み・デコードに失敗した場合、または自然寸法から縦横比を
 /// 算出できない場合に [`PdfGenError`] を返します。
 pub fn resolve_images(blocks: Vec<Block>, text_width: f32) -> Result<Vec<Block>, PdfGenError> {
-  return blocks
+  let resolved = blocks
     .into_iter()
     .map(|block| match block {
       Block::Image {
@@ -52,7 +53,10 @@ pub fn resolve_images(blocks: Vec<Block>, text_width: f32) -> Result<Vec<Block>,
       },
       other => Ok(other),
     })
-    .collect();
+    .collect::<Result<Vec<Block>, PdfGenError>>()?;
+  let image_count = resolved.iter().filter(|block| matches!(block, Block::Image { .. })).count();
+  debug!(image_count, "画像サイズを確定しました");
+  return Ok(resolved);
 }
 
 /// `load_image` が返す画像表現。

--- a/crates/pdf_gen/src/lib.rs
+++ b/crates/pdf_gen/src/lib.rs
@@ -16,6 +16,7 @@ use hlist::Page;
 use krilla::{Document, page::PageSettings};
 use read_config::Config;
 use read_style::Style;
+use tracing::debug;
 use types::HeadingLevel;
 
 pub use crate::{error::PdfGenError, image::resolve_images};
@@ -73,5 +74,6 @@ pub fn create_pdf(
   document.set_metadata(build_metadata(config));
   render_pages(&mut document, &page_settings, config, metrics, &krilla_fonts, pages, style, outline_entries)?;
   let pdf_bytes = document.finish().map_err(|source| PdfGenError::FinalizeDocument { source })?;
+  debug!(page_count = pages.len(), "PDF 描画が完了しました");
   return Ok(pdf_bytes);
 }

--- a/crates/read_config/src/lib.rs
+++ b/crates/read_config/src/lib.rs
@@ -11,7 +11,7 @@ use std::{
 use garde::Validate;
 use miette::{Diagnostic, NamedSource, SourceSpan};
 use thiserror::Error;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 use types::FontType;
 
 mod pre_config;
@@ -196,7 +196,7 @@ struct FontValues {
 // allow する。`config.toml` は 1 回しか読まないので最適化対象ではない。
 #[allow(clippy::result_large_err)]
 pub fn read_config(config_path: &Path) -> Result<Config, ReadConfigError> {
-  info!(config_path = %config_path.display(), "設定ファイルの読み込みを開始します");
+  debug!(config_path = %config_path.display(), "設定ファイルの読み込みを開始します");
   let config_content = fs::read_to_string(config_path).map_err(|source| ReadConfigError::ReadFile {
     path: config_path.display().to_string(),
     source,
@@ -451,7 +451,7 @@ fn canonicalize_sources(sources: &[PathBuf], current_dir: &Path, errors: &mut Ve
   for source_path in sources {
     if source_path.extension().and_then(|ext| ext.to_str()) != Some("sei") {
       warn!(
-        path = %source_path.display(),
+        source_path = %source_path.display(),
         "ソースファイルの拡張子が `.sei` ではありません。Seiran は `.sei` 拡張子を推奨します。"
       );
     }

--- a/crates/read_references/src/lib.rs
+++ b/crates/read_references/src/lib.rs
@@ -33,7 +33,7 @@ pub use date::{Date, DateCirca, DatePart, DateSeason};
 pub use error::ReadReferencesError;
 pub use name::Name;
 pub use reference::{NumberOrString, Reference, ReferenceType, References};
-use tracing::info;
+use tracing::{debug, info};
 
 /// 参照定義ファイルの形式
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -73,14 +73,14 @@ pub fn read_references<P: AsRef<Path>>(path: Option<P>) -> Result<References, Re
     return Ok(References(HashMap::new()));
   };
   let path_ref = path.as_ref();
-  info!(references_path = %path_ref.display(), "参照定義ファイルの読み込みを開始します");
+  debug!(references_path = %path_ref.display(), "参照定義ファイルの読み込みを開始します");
   let content = std::fs::read_to_string(path_ref).map_err(|source| ReadReferencesError::ReadFile {
     path: path_ref.display().to_string(),
     source,
   })?;
   let references = parse_references(&content, path_ref)?;
-  let count = references.len();
-  info!(count, "参照定義ファイルの読み込みが完了しました");
+  let reference_count = references.len();
+  info!(reference_count, "参照定義ファイルの読み込みが完了しました");
   return Ok(references);
 }
 

--- a/crates/read_style/src/lib.rs
+++ b/crates/read_style/src/lib.rs
@@ -39,7 +39,7 @@ use std::{fs, path::Path};
 
 use garde::Validate;
 use miette::{NamedSource, SourceSpan};
-use tracing::info;
+use tracing::{debug, info};
 
 pub use crate::{
   caption::CaptionStyle,
@@ -82,7 +82,7 @@ pub fn read_style(path: Option<&Path>) -> Result<Style, ReadStyleError> {
     return Ok(Style::default());
   };
   let path_str = path.display().to_string();
-  info!(style_path = %path_str, "スタイル設定ファイルの読み込みを開始します");
+  debug!(style_path = %path_str, "スタイル設定ファイルの読み込みを開始します");
 
   let content = fs::read_to_string(path).map_err(|source| ReadStyleError::ReadFile {
     path: path_str.clone(),

--- a/crates/seiran/src/build_pdf.rs
+++ b/crates/seiran/src/build_pdf.rs
@@ -2,7 +2,7 @@
 //! このモジュールは、設定ファイルの `sources` に列挙されたテキストファイルから
 //! PDF を生成するための主要な機能を提供します。
 
-use std::{collections::HashSet, fs, path::Path};
+use std::{collections::HashSet, fs, path::Path, time::Instant};
 
 use citation::CitationError;
 use document::DocNode;
@@ -15,7 +15,7 @@ use lowering::{LoweringContext, LoweringError};
 use miette::Diagnostic;
 use parser::ParseSourceError;
 use thiserror::Error;
-use tracing::info;
+use tracing::{debug, info};
 
 /// PDF ビルド時のエラー型
 #[derive(Debug, Error, Diagnostic)]
@@ -99,6 +99,7 @@ enum BuildPdfError {
 ///
 /// * `config_path` - 設定ファイルのパス
 pub(super) fn build_pdf(config_path: &Path) -> miette::Result<()> {
+  let build_start = Instant::now();
   info!(config_path = %config_path.display(), "PDF のビルドを開始します");
 
   let config = read_config::read_config(config_path)?;
@@ -107,31 +108,41 @@ pub(super) fn build_pdf(config_path: &Path) -> miette::Result<()> {
   // `\cite` のキー存在検証に使う有効な参照 ID 集合（CSL 整形そのものは後続の citation ステージで実施）
   let citation_keys: HashSet<String> = references.keys().cloned().collect();
 
+  let stage_start = Instant::now();
   let mut doc_nodes = parse_all_sources(&config.sources, &style, &citation_keys)?;
-  info!(source_count = config.sources.len(), "全ソースのパースが完了しました");
+  info!(
+    source_count = config.sources.len(),
+    node_count = doc_nodes.len(),
+    elapsed_ms = elapsed_ms(stage_start),
+    "全ソースのパースが完了しました"
+  );
 
   // `\cite` を CSL 整形し、引用された文献の書誌を本文末尾に追加する（parser の後・lowering の前）。
+  let stage_start = Instant::now();
   citation::process_citations(&mut doc_nodes, &references, &style)
     .map_err(|source| BuildPdfError::Citation { source })?;
-  info!("文献引用の CSL 整形が完了しました");
+  info!(elapsed_ms = elapsed_ms(stage_start), "文献引用の CSL 整形が完了しました");
 
+  let stage_start = Instant::now();
   let lowering_ctx = LoweringContext::new(&style);
   let body_layout_nodes =
     lowering::lower_nodes(&lowering_ctx, &doc_nodes).map_err(|source| BuildPdfError::Lowering { source })?;
-  info!("Document IR → LayoutNode への変換が完了しました");
+  info!(elapsed_ms = elapsed_ms(stage_start), "Document IR → LayoutNode への変換が完了しました");
 
+  let stage_start = Instant::now();
   let font_data = FontData::new(&config.font_configs)?;
-  info!("フォントの読み込みが完了しました");
+  info!(elapsed_ms = elapsed_ms(stage_start), "フォントの読み込みが完了しました");
 
   let font_refs = FontRefs::new(&config.font_configs, &font_data)?;
 
+  let stage_start = Instant::now();
   validate_font::validate_fonts(&config.font_configs, &font_refs)?;
-  info!("フォントの検証が完了しました");
+  info!(elapsed_ms = elapsed_ms(stage_start), "フォントの検証が完了しました");
 
   let shaper_datas = ShaperDatas::new(&font_refs);
   let shaper_instances = ShaperInstances::new(&config.font_configs, &font_refs);
   let harf_rust_shapers = HarfRustShapers::new(&config.font_configs, &font_refs, &shaper_datas, &shaper_instances)?;
-  info!("シェーパーの初期化が完了しました");
+  debug!("シェーパーの初期化が完了しました");
 
   let metrics = FontMetrics::new(&font_refs)?;
 
@@ -140,10 +151,18 @@ pub(super) fn build_pdf(config_path: &Path) -> miette::Result<()> {
   let default_font_size = style.font_size.to_pt();
   let line_height_factor = style.line_height_factor;
 
+  let stage_start = Instant::now();
   let body_blocks =
     layout::build_blocks(body_layout_nodes, &harf_rust_shapers, &metrics, default_font_size, line_height_factor);
+  info!(
+    block_count = body_blocks.len(),
+    elapsed_ms = elapsed_ms(stage_start),
+    "本文ブロックの構築が完了しました"
+  );
+
+  let stage_start = Instant::now();
   let body_blocks = pdf_gen::resolve_images(body_blocks, text_width)?;
-  info!("本文ブロックの構築が完了しました");
+  info!(elapsed_ms = elapsed_ms(stage_start), "画像サイズの確定が完了しました");
 
   let geometry = hlist::PageGeometry {
     margin_top: config.pdf.margin.top.to_pt(),
@@ -156,10 +175,11 @@ pub(super) fn build_pdf(config_path: &Path) -> miette::Result<()> {
   // Pass 1: 本文だけを単独でページ分割し、各見出しの本文内ページ index を採取する。
   // 本文は前付け（タイトルページ・目次）と別系列で 1 から番号付けするため、ここで得る本文内
   // ページ番号が最終値になる（前付けの長さに不依存 = R1。break_pages は純粋なので安価）。
+  let stage_start = Instant::now();
   let body_pages = hlist::break_pages(body_blocks.clone(), text_width, &geometry, &hlist::GreedyBreaker);
   let body_page_count = body_pages.len();
   let heading_pages = heading_page_indices(&body_pages);
-  info!(body_page_count, "本文の Pass 1 ページ分割が完了しました");
+  info!(body_page_count, elapsed_ms = elapsed_ms(stage_start), "本文のページ分割が完了しました（Pass 1）");
 
   // 前付けブロック（タイトルページ → 目次）を組み立てる。各リージョンは改ページ境界で始まる。
   let mut front_blocks: Vec<hlist::Block> = Vec::new();
@@ -178,7 +198,7 @@ pub(super) fn build_pdf(config_path: &Path) -> miette::Result<()> {
       default_font_size,
       line_height_factor,
     ));
-    info!("タイトルページを生成しました");
+    debug!("タイトルページを生成しました");
   }
   if style.toc.enabled {
     let toc_entries = collect_toc_entries(&doc_nodes, &heading_pages, &style.toc, &style.page_numbering);
@@ -188,18 +208,25 @@ pub(super) fn build_pdf(config_path: &Path) -> miette::Result<()> {
       front_blocks.extend(toc_blocks);
       // 目次の後で改ページし、本文を次ページから始める（本文区間の独立性を保つ）。
       front_blocks.push(hlist::Block::PageBreak);
-      info!(entry_count = toc_entries.len(), "目次を生成しました");
+      debug!(toc_entry_count = toc_entries.len(), "目次を生成しました");
     }
   }
 
   // Pass 2: 前付け + 本文を結合して最終ページを確定する。本文区間のページ分割は Pass 1 と
   // 一致する（本文は常に改ページ境界から始まるため）。
+  let stage_start = Instant::now();
   let mut combined = front_blocks;
   combined.extend(body_blocks);
   let mut pages = hlist::break_pages(combined, text_width, &geometry, &hlist::GreedyBreaker);
   let front_matter_count = pages.len().saturating_sub(body_page_count);
   debug_assert_eq!(pages.len(), front_matter_count + body_page_count, "本文区間のページ数は Pass 1 と一致するはず");
-  info!(page_count = pages.len(), front_matter_count, "レイアウトの計算が完了しました");
+  info!(
+    page_count = pages.len(),
+    front_matter_count,
+    body_page_count,
+    elapsed_ms = elapsed_ms(stage_start),
+    "ページ分割が完了しました（Pass 2）"
+  );
 
   // ページ番号ラベルを算出する（前付け = ローマ数字 / 本文 = 算用数字、各リージョン 1 から）。
   let page_numbers = page_number_labels(pages.len(), front_matter_count, body_page_count, &style.page_numbering);
@@ -225,17 +252,24 @@ pub(super) fn build_pdf(config_path: &Path) -> miette::Result<()> {
   // lowering が各見出しの直前に出すアンカーと文書順で 1 対 1 に対応する。
   let outline_entries = collect_outline_entries(&doc_nodes);
 
+  let stage_start = Instant::now();
   let pdf_bytes = pdf_gen::create_pdf(&config, &font_data, &font_refs, &metrics, &pages, &style, &outline_entries)?;
+  info!(page_count = pages.len(), elapsed_ms = elapsed_ms(stage_start), "PDF の描画が完了しました");
 
+  let stage_start = Instant::now();
   let output_path = config.output.pdf_path();
   fs::write(&output_path, pdf_bytes).map_err(|source| BuildPdfError::WritePdf {
     path: output_path.display().to_string(),
     source,
   })?;
-  info!(output_path = %output_path.display(), "PDF の保存が完了しました");
+  info!(output_path = %output_path.display(), elapsed_ms = elapsed_ms(stage_start), "PDF の保存が完了しました");
 
+  info!(page_count = pages.len(), total_elapsed_ms = elapsed_ms(build_start), "ビルドが完了しました");
   return Ok(());
 }
+
+/// ステージ開始時刻からの経過ミリ秒を返す（INFO サマリの `elapsed_ms` 用）。
+fn elapsed_ms(start: Instant) -> u64 { return start.elapsed().as_millis() as u64; }
 
 /// Document IR の見出しから PDF しおり用の [`pdf_gen::OutlineEntry`] を文書順に組み立てる。
 ///

--- a/crates/seiran/src/main.rs
+++ b/crates/seiran/src/main.rs
@@ -29,8 +29,33 @@
 //!
 //! ## ロギング
 //!
-//! INFO レベル以上のトレーシングログを出力します。
-//! タイムスタンプ付きで標準エラー出力に記録されます。
+//! 既定では INFO レベル以上のトレーシングログを、RFC 3339 タイムスタンプ付きで標準エラー出力に
+//! 記録します。観測・進捗の表示は `tracing` が担い、ユーザ向けの致命的エラーは `miette` 診断が
+//! 担当します（役割を二重化しない）。
+//!
+//! ### レベル方針（taxonomy）
+//!
+//! - **ERROR**: 原則使わない。ユーザ向けの致命的エラーは `miette` 診断が担当し、`tracing` の
+//!   ERROR と二重化しない。
+//! - **WARN**: 処理は続行するが利用者が知るべき事象（フォントフォールバック、ソース拡張子の
+//!   不一致、GSUB / GPOS テーブル欠如など）。
+//! - **INFO**: 既定表示。build パイプラインの各ステージ完了とサマリ指標（件数・ページ数・所要
+//!   時間 `elapsed_ms`）のみ。「実行を追える粒度」に限定する。
+//! - **DEBUG**: 段の内部詳細（ソースごと・ブロックごと・ページごと・フォントごと等のループ
+//!   単位）。各コア処理クレートが自段の完了を DEBUG で出す。
+//! - **TRACE**: 最細粒度（トークン・グリフ単位）。現状は未使用（枠のみ定義）。
+//!
+//! ### 構造化フィールドの命名規約
+//!
+//! - パスは `<entity>_path`（例: `config_path` / `source_path` / `output_path`）。
+//! - 件数は `<entity>_count`（例: `source_count` / `page_count` / `block_count`）。
+//! - 時間はステージが `elapsed_ms`、ビルド全体が `total_elapsed_ms`。
+//!
+//! ### 冗長度の制御（別 issue）
+//!
+//! DEBUG / TRACE を実際に画面へ出す制御手段（`RUST_LOG` / `EnvFilter` や `-v` / `-q` フラグ）は
+//! 本バージョンでは未導入で、既定では INFO のみを表示する（`with_max_level(INFO)` で固定）。
+//! DEBUG / TRACE はコンパイルされるが既定では出力されない。
 
 mod build_pdf;
 use tracing_subscriber::fmt;
@@ -47,6 +72,7 @@ use tracing_subscriber::fmt;
 fn main() -> miette::Result<()> {
   fmt::fmt()
     .pretty()
+    .with_max_level(tracing::Level::INFO)
     .with_thread_ids(false)
     .with_thread_names(false)
     .with_target(false)

--- a/crates/subcommand/src/get_ttc_names.rs
+++ b/crates/subcommand/src/get_ttc_names.rs
@@ -125,7 +125,7 @@ enum TtcNamesError {
 /// ```
 pub fn get_ttc_names(file_path: &Path) -> miette::Result<()> {
   // TTC ファイルパスをログに記録
-  info!(ttc_file_path = %file_path.display(), "Input TTC file path");
+  info!(ttc_path = %file_path.display(), "TTC ファイルを読み込みます");
 
   // TTC ファイルをすべてメモリに読み込み
   let data = fs::read(file_path).map_err(|source| TtcNamesError::ReadFile {

--- a/crates/subcommand/src/get_variation_axes.rs
+++ b/crates/subcommand/src/get_variation_axes.rs
@@ -140,7 +140,7 @@ enum VariationAxesError {
 /// ```
 pub fn get_variation_axes(font_path: &Path, font_index: u32) -> miette::Result<()> {
   // ファイルパスとインデックスをログに記録
-  info!(font_file_path = %font_path.display(), font_index = font_index, "Input font file path and index");
+  info!(font_path = %font_path.display(), font_index, "フォントファイルを読み込みます");
 
   // フォントファイルをすべてメモリに読み込み
   let font_bytes = fs::read(font_path).map_err(|source| VariationAxesError::ReadFile {

--- a/crates/subcommand/src/script_langs.rs
+++ b/crates/subcommand/src/script_langs.rs
@@ -239,7 +239,7 @@ enum ScriptLangsError {
 /// seiran script-langs fonts/NotoSerifJP.otf
 /// ```
 pub fn script_langs(file_path: &Path, font_index: u32) -> miette::Result<()> {
-  info!(font_file_path = %file_path.display(), font_index = font_index, "Input font file path and index");
+  info!(font_path = %file_path.display(), font_index, "フォントファイルを読み込みます");
 
   // Script/Language System から参照された Feature タグを収集する（統計処理で使用）
   let mut referenced_features = BTreeSet::new();

--- a/crates/syntax/Cargo.toml
+++ b/crates/syntax/Cargo.toml
@@ -12,6 +12,7 @@ bumpalo.workspace = true
 memchr.workspace = true
 miette.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
 
 [lints]
 workspace = true

--- a/crates/syntax/src/parser.rs
+++ b/crates/syntax/src/parser.rs
@@ -13,6 +13,7 @@
 //!   `Vec` の個別ヒープ確保を排除
 
 use bumpalo::Bump;
+use tracing::debug;
 
 use crate::{
   cst::{
@@ -716,7 +717,9 @@ pub fn parse<'a>(
 ) -> Result<&'a GreenNode<'a>, ParserError> {
   let lexer = Lexer::new(source);
   let mut parser = Parser::new(source, lexer, arena, env_mode);
-  return parser.parse_root();
+  let root = parser.parse_root()?;
+  debug!(source_bytes = source.len(), "CST の構築が完了しました");
+  return Ok(root);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 概要

build パイプラインの全段を一貫したレベル方針でログ出力し、ビルド進捗（どの段で何件・何ページ処理し、各段に何 ms かかったか）を一目で追えるようにする。散在・不統一だったログを整理し、新規ログを足すときの基準を確立する。Closes #103

## 変更内容

### レベル方針（taxonomy）と命名規約の明文化 — `crates/seiran/src/main.rs`
- `## ロギング` doc に ERROR/WARN/INFO/DEBUG/TRACE の用途、`tracing`（観測・進捗）↔ `miette`（ユーザ向け致命エラー）の線引き、構造化フィールド命名規約、冗長度制御が別 issue である旨を記載。
- `fmt()` チェーンに `.with_max_level(tracing::Level::INFO)` を追加し、DEBUG/TRACE を既定で抑止（INFO デフォルト表示を保証）。`EnvFilter`/`-v` 導入とは別物の静的な既定固定。

### INFO 層の網羅・一貫化 + 段ごと所要時間 — `crates/seiran/src/build_pdf.rs`
- private ヘルパ `elapsed_ms(Instant) -> u64` を追加し、各ステージ直前に `Instant::now()` をシャドウ、完了 INFO に `elapsed_ms` を付与。先頭で `build_start` を取り、末尾に「ビルドが完了しました」（`total_elapsed_ms`）を出す。
- INFO サマリ対象段を issue のリストに整列: パース（`source_count`/`node_count`）／CSL 整形／lowering／フォント読込／フォント検証／build_blocks（`block_count`）／**resolve_images を新規分離**／break_pages Pass 1（`body_page_count`）／Pass 2（`page_count`/`front_matter_count`/`body_page_count`）／**render を新設**（`page_count`）／出力。
- ループ単位・内部サブステップを DEBUG へ降格: シェーパー初期化・タイトルページ生成・目次生成（`entry_count`→`toc_entry_count`）。

### コア処理クレートへの DEBUG 計装（各 `Cargo.toml` に `tracing` 追加）
公開エントリの完了点にサマリ DEBUG を 1 つずつ追加。
- `parser::parse_source` — `source_path`/`node_count`（ソースごとの内訳）
- `syntax::parse` — `source_bytes`
- `citation::process_citations` — `citation_count`/`bibliography_count`
- `lowering::lower_nodes` — `input_node_count`/`layout_node_count`
- `layout::build_blocks` — `block_count`、`build_running_content` — `page_count`
- `hlist::break_pages` — `block_count`/`page_count`（Pass 1/2 双方で発火）
- `pdf_gen::create_pdf` — `page_count`、`resolve_images` — `image_count`

### 既存ログの整理（I/O 系 + font + subcommand）
- `read_config`/`read_style`/`read_references`: 「…読み込みを開始します」を INFO→DEBUG（完了のみ INFO）。`read_references` の `count`→`reference_count`、`read_config` の warn フィールド `path`→`source_path`。
- `font::validate_font`: per-font 完了ログ（ループ単位）を INFO→DEBUG（「フォントを検証しました」）。集約 INFO は `build_pdf` 側。WARN 群はそのまま。
- `subcommand`（`get_ttc_names`/`get_variation_axes`/`script_langs`）: 英語メッセージを日本語化、`ttc_file_path`→`ttc_path`・`font_file_path`→`font_path`。

## 設計上の判断

- **`tracing` と `miette` の線引き** → ユーザ向け致命エラーは `miette`、進捗・観測は `tracing`。ERROR レベルは原則使わない。
- **INFO の粒度** → 「ビルドを追える」最小限に限定。ループ単位（ソース・ブロック・ページ・フォントごと）は DEBUG に落とし、`with_max_level(INFO)` で既定表示を汚さないことを保証。
- **DEBUG の可視化** → 本 PR では DEBUG/TRACE はコンパイルされるが既定では非表示。実際に画面へ出す制御手段（`RUST_LOG`/`EnvFilter`・`-v`/`-q`）は別 issue（下記スコープ外）。

## テスト

- `cargo build` / `cargo clippy --all-targets` / `cargo test` / `cargo +nightly fmt` すべてパス。
- `cargo run -- build` の stderr を目視確認: 全 INFO 段が `elapsed_ms` 付き・日本語・規約どおりのフィールドで 1 行ずつ出力され、降格項目（シェーパー初期化・per-font 検証・タイトルページ・目次・各「開始します」）が INFO に出ないこと、font の WARN が維持されることを確認。
- `with_max_level` を一時的に DEBUG にして、各コアクレートの DEBUG（per-source パース含む）が発火することを確認（コミットには含めず INFO に復帰）。
- `cargo run -- ttc-names …` のログが日本語かつ `ttc_path` で出ることを確認。

## スコープ外

- 冗長度の制御（`RUST_LOG`/`EnvFilter`、`-v`/`-vv`/`-q` フラグ）— 別 issue。DEBUG/TRACE を画面に出す手段はここでは導入せず、INFO デフォルトのまま整える（本 PR の DEBUG 可視化の前提となる follow-up）。
- 出力フォーマットの選択（pretty/json 切替、ターゲット表示の有無）— 別 issue。
- プログレスバー等の TUI 的表現。

## 関連

- Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)