### PR TITLE
数式: equation 環境の無採番指定（[numbered=false]）対応

### DIFF
--- a/crates/parser/src/evaluator/environment/math/equation.rs
+++ b/crates/parser/src/evaluator/environment/math/equation.rs
@@ -8,6 +8,9 @@
 //! ## 任意引数
 //!
 //! - `[label=eq:foo]` — `\ref` 解決用ラベル（任意）
+//! - `[numbered=false]` — 本体を無採番にする（既定は採番あり）。`align` 等 4 環境の `[numbered]` と
+//!   同一意味論。無採番のときは equation カウンタを消費しない（後続の採番式の通し番号が連続する）。
+//!   無採番の式に `[label=...]` を併用するとエラー（参照番号が存在しないため）
 
 use document::{DocNode, MathEnvKind, MathRow};
 use read_style::CounterName;
@@ -16,21 +19,26 @@ use syntax::ast::EnvironmentView;
 use super::math_grid::{GridSpec, evaluate_grid};
 use crate::evaluator::{
   EvalError, Evaluator,
-  opt_args::{OptType, collect_environment_opt_args, find_string},
+  opt_args::{OptType, collect_environment_opt_args, find_bool, find_string},
 };
 
 /// `equation` 環境を評価する
 ///
-/// [`CounterRegistry::increment`] で `CounterName::Equation` の通し番号を発番し、
+/// 既定では [`CounterRegistry::increment`] で `CounterName::Equation` の通し番号を発番し、
 /// `[label=...]` 指定時はそのレジストリにラベルを登録する。番号書式は
-/// `read_style::CounterStyle.format` テンプレ（既定 `"{chapter}.{n}"`）に従う。本体は
+/// `read_style::CounterStyle.format` テンプレ（既定 `"{chapter}.{n}"`）に従う。`[numbered=false]`
+/// 指定時は採番を一切行わず（カウンタを消費しない）、`row.number` は `None` になる。本体は
 /// 単一行・単一セルとして評価し、`MathRow` 1 件の `MathBlock` を返す。
 ///
 /// # Errors
 ///
-/// 不明な任意引数キーや値の型不一致、本体への `&` / `\\` の混入時にエラーを返します
+/// 不明な任意引数キーや値の型不一致、本体への `&` / `\\` の混入時にエラーを返します。
+/// `[numbered=false]` と `[label=...]` を併用した場合は [`EvalError::LabelRequiresNumbering`] を返します
 pub(crate) fn equation(view: &EnvironmentView, evaluator: &mut Evaluator) -> Result<Vec<DocNode>, EvalError> {
-  let opt_args = collect_environment_opt_args(view, &[("label", OptType::String)])?;
+  let opt_args = collect_environment_opt_args(view, &[("label", OptType::String), ("numbered", OptType::Bool)])?;
+  // label と numbered の 2 キーを取り出す。find_* は引数を消費するため bool 抽出には複製を渡す
+  // （任意引数は高々 2 要素で複製は軽量）
+  let numbered = find_bool(opt_args.clone(), "numbered").unwrap_or(true);
   let label = find_string(opt_args, "label");
   if !view.args().is_empty() {
     return Err(EvalError::ExtraEnvironmentArgument {
@@ -38,10 +46,24 @@ pub(crate) fn equation(view: &EnvironmentView, evaluator: &mut Evaluator) -> Res
       span: view.span().into(),
     });
   }
+  // 無採番の式は参照番号を持たないため、ラベルとの併用を禁じる
+  if !numbered && label.is_some() {
+    return Err(EvalError::LabelRequiresNumbering {
+      name: "equation".to_string(),
+      span: view.span().into(),
+    });
+  }
 
-  let number = evaluator
-    .registry
-    .increment_with_label(CounterName::Equation, label.as_deref(), view.span().into())?;
+  // `[numbered=false]` のときは採番せず（カウンタも消費しない）番号は持たせない
+  let number = if numbered {
+    Some(
+      evaluator
+        .registry
+        .increment_with_label(CounterName::Equation, label.as_deref(), view.span().into())?,
+    )
+  } else {
+    None
+  };
 
   let source = view.source();
   // equation は単一行・単一セル。行区切り `\\`・列区切り `&` はエラーにする
@@ -60,7 +82,7 @@ pub(crate) fn equation(view: &EnvironmentView, evaluator: &mut Evaluator) -> Res
 
   let row = MathRow {
     cells,
-    number: Some(number),
+    number,
     label,
   };
   return Ok(vec![DocNode::MathBlock {
@@ -207,7 +229,7 @@ mod tests {
 
   #[test]
   fn equation_rejects_unknown_opt_key() {
-    // Arrange — equation は label のみ許可、未知キーはエラー
+    // Arrange — equation は label / numbered のみ許可、未知キーはエラー
     let arena = Bump::new();
     let source = r"\begin{equation}[foo=1]x\end{equation}";
     let cst = parse(source, &arena).unwrap();
@@ -218,6 +240,78 @@ mod tests {
 
     // Assert
     assert!(matches!(result, Err(EvalError::UnknownOptArgKey { ref key, .. }) if key == "foo"));
+  }
+
+  #[test]
+  fn equation_numbered_false_suppresses_numbering() {
+    // Arrange — `[numbered=false]` で無採番（number が None）になる
+    let arena = Bump::new();
+    let source = r"\begin{equation}[numbered=false]x\end{equation}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::new(&style_with_plain_equation_format());
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst).unwrap();
+
+    // Assert — 行は出るが番号は持たない
+    assert_eq!(result.len(), 1);
+    let row = first_row(&result);
+    assert!(row.number.is_none(), "無採番なので number は None: {:?}", row.number);
+  }
+
+  #[test]
+  fn equation_numbered_false_does_not_consume_counter() {
+    // Arrange — 無採番 → 採番の並びで、採番側の通し番号が "1" から始まる（無採番はカウンタ非消費）
+    let arena = Bump::new();
+    let source = r"\begin{equation}[numbered=false]a\end{equation}\begin{equation}b\end{equation}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::new(&style_with_plain_equation_format());
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst).unwrap();
+
+    // Assert — 1 つ目は無採番、2 つ目は通し番号が連続して "1"
+    assert_eq!(result.len(), 2);
+    let numbers: Vec<Option<&str>> = result
+      .iter()
+      .map(|n| match n {
+        DocNode::MathBlock { rows, .. } => rows[0].number.as_deref(),
+        _ => panic!("MathBlock が期待されます: {n:?}"),
+      })
+      .collect();
+    assert_eq!(numbers, vec![None, Some("1")]);
+  }
+
+  #[test]
+  fn equation_numbered_true_is_explicit_default() {
+    // Arrange — `[numbered=true]` 明示は既定（採番あり）と同じ
+    let arena = Bump::new();
+    let source = r"\begin{equation}[numbered=true]x\end{equation}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::new(&style_with_plain_equation_format());
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst).unwrap();
+
+    // Assert
+    assert_eq!(result.len(), 1);
+    let row = first_row(&result);
+    assert_eq!(row.number.as_deref(), Some("1"));
+  }
+
+  #[test]
+  fn equation_numbered_false_with_label_errors() {
+    // Arrange — 無採番の式にラベルを付けるとエラー（参照番号が存在しないため）
+    let arena = Bump::new();
+    let source = r"\begin{equation}[numbered=false][label=eq:x]a\end{equation}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::default();
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst);
+
+    // Assert
+    assert!(matches!(result, Err(EvalError::LabelRequiresNumbering { ref name, .. }) if name == "equation"));
   }
 
   #[test]

--- a/crates/parser/src/evaluator/error.rs
+++ b/crates/parser/src/evaluator/error.rs
@@ -198,6 +198,22 @@ pub enum EvalError {
     span: SourceSpan,
   },
 
+  /// 無採番（`[numbered=false]`）の数式環境にラベル（`[label=...]`）を付与した場合
+  ///
+  /// 無採番の式は参照番号を持たないため、ラベルを付けても `\ref` で解決できる対象がない。
+  #[error("無採番の数式にラベルは付けられません: {name}")]
+  #[diagnostic(
+    code(parser::eval::label_requires_numbering),
+    help("ラベルは参照番号を前提とします。[numbered=false] を外すか [label=...] を外してください。")
+  )]
+  LabelRequiresNumbering {
+    /// 環境名（先頭の `\` は含めない）
+    name: String,
+    /// 環境のソース位置
+    #[label("無採番の式にはラベルを付けられません")]
+    span: SourceSpan,
+  },
+
   /// インライン文脈（見出しタイトル・キャプション・インライン装飾の引数）に
   /// ブロックレベルの要素が出現した場合
   #[error("インライン文脈では使用できません: {what}")]


### PR DESCRIPTION
## 概要

ディスプレイ数式 `equation` に環境単位の `[numbered=false]` を追加し、単一式を無採番にできるようにする。これまで `align` / `gather` / `split` / `multiline` の 4 環境だけが対応しており、`equation` は `[label=...]` のみ受け付け常に採番されていた。LaTeX の `equation*` 相当を、Seiran 方針どおり `*` 接尾辞ではなくオプション引数で表現する。

## 変更内容

- **`crates/parser/src/evaluator/environment/math/equation.rs`**
  - opt スキーマに `("numbered", OptType::Bool)` を追加。`find_bool(...).unwrap_or(true)` で取得し、`math_grid.rs::evaluate_math_env`（他 4 環境）と同一意味論（既定 `true`）に揃えた。
  - `[numbered=false]` のときは `increment_with_label` を呼ばず `row.number = None` にする。これにより `CounterName::Equation` を消費せず、前後の採番式の通し番号が連続する。
  - `[numbered=false]` かつ `[label=...]` の併用を `EvalError::LabelRequiresNumbering` で弾く。
  - `find_*` ヘルパは引数（`Vec<(String, OptValue)>`）を消費するため、2 キー（`label` / `numbered`）取得にあたり bool 抽出へ複製を 1 回渡している（任意引数は高々 2 要素で軽量）。
- **`crates/parser/src/evaluator/error.rs`**
  - エラー variant `LabelRequiresNumbering`（`code(parser::eval::label_requires_numbering)`）を追加。将来 align 等にラベル対応（#76）が入っても再利用できるよう、環境名を持つ汎用形にした。

## 設計上の判断

- **`[numbered]` と `[label]` の共存ルール**: 無採番の式は参照番号を持たないため、`[numbered=false]` + `[label=...]` はエラーとした（issue の提案どおり）。黙って label を無視する案も検討したが、後で `\ref` すると `UnknownLabel` になり原因が分かりにくいため、指定時点で弾く方を採った。
- **実装は `equation.rs` 内で完結**: equation は label を持つ唯一の数式環境で、共通ハンドラ `evaluate_math_env`（label 非対応・`PerRow`/`SingleEnv` 分岐あり）と構造が異なる。`evaluate_math_env` へ寄せず、`[numbered]` の解釈だけを揃えた。

## テスト

`equation.rs` に AAA パターンで 4 件追加（既存ヘルパ `style_with_plain_equation_format` / `first_row` を再利用）:

- `equation_numbered_false_suppresses_numbering` — `[numbered=false]` で `number` が `None`
- `equation_numbered_false_does_not_consume_counter` — 無採番→採番の並びで採番側が `"1"` から始まる（カウンタ非消費）
- `equation_numbered_true_is_explicit_default` — `[numbered=true]` 明示が既定と同じ
- `equation_numbered_false_with_label_errors` — label 併用が `LabelRequiresNumbering`

既存テストは挙動不変。`cargo test`（pre-commit フックで全 workspace パス）/ `cargo clippy --workspace`（警告ゼロ）/ `cargo +nightly fmt` 済み。

## スコープ外

- 行単位の無採番（`\notag` 相当）→ #74
- align / gather / split / multiline のラベル付け（`[label=...]` / `\ref`）→ #76

## 関連

Closes #107
- #25 高度な数式環境（環境単位 `[numbered=false]` の出典）