### PR TITLE
パーサ: 任意引数ヘルパを借用化して複数キー抽出を可能にする

### DIFF
--- a/crates/parser/src/evaluator/command/headline.rs
+++ b/crates/parser/src/evaluator/command/headline.rs
@@ -36,7 +36,7 @@ pub(super) fn heading(
   let name = level.command_name();
 
   let opt_args = collect_command_opt_args(view, &[("label", OptType::String)])?;
-  let label = find_string(opt_args, "label");
+  let label = find_string(&opt_args, "label");
 
   let Some(first_arg) = view.first_arg() else {
     return Err(EvalError::MissingCommandArgument {

--- a/crates/parser/src/evaluator/command/inline.rs
+++ b/crates/parser/src/evaluator/command/inline.rs
@@ -61,7 +61,7 @@ pub(crate) fn styled_text(view: &CommandView, kind: FontKind) -> Result<Vec<Inli
 pub(crate) fn colored_text(view: &CommandView) -> Result<Vec<InlineNode>, EvalError> {
   let name = view.name();
   let opt_args = collect_command_opt_args(view, &[("color", OptType::Color)])?;
-  let Some(color) = find_color(opt_args, "color") else {
+  let Some(color) = find_color(&opt_args, "color") else {
     return Err(EvalError::MissingCommandArgument {
       name: name.to_string(),
       expected: "色 (color=#rrggbb)".to_string(),

--- a/crates/parser/src/evaluator/command/link.rs
+++ b/crates/parser/src/evaluator/command/link.rs
@@ -55,7 +55,7 @@ pub(crate) fn url_command(view: &CommandView) -> Result<Vec<InlineNode>, EvalErr
 /// 任意引数 `url` の欠落・型不正、必須引数（表示テキスト）の欠落 / 過剰でエラーを返します。
 pub(crate) fn href_command(view: &CommandView) -> Result<Vec<InlineNode>, EvalError> {
   let opt_args = collect_command_opt_args(view, &[("url", OptType::String)])?;
-  let Some(url) = find_string(opt_args, "url") else {
+  let Some(url) = find_string(&opt_args, "url") else {
     return Err(EvalError::MissingCommandArgument {
       name: "href".to_string(),
       expected: "[url=...]（リンク先 URI）".to_string(),

--- a/crates/parser/src/evaluator/environment/figure.rs
+++ b/crates/parser/src/evaluator/environment/figure.rs
@@ -40,7 +40,7 @@ use crate::evaluator::{
 /// 未知の任意引数キー、`\image` の必須パラメータ不足などが発生した場合にエラーを返します。
 pub(super) fn figure(view: &EnvironmentView, evaluator: &mut Evaluator) -> Result<Vec<DocNode>, EvalError> {
   let opt_args = collect_environment_opt_args(view, &[("label", OptType::String)])?;
-  let label = find_string(opt_args, "label");
+  let label = find_string(&opt_args, "label");
 
   let number = evaluator.registry.increment_with_label(CounterName::Figure, label.as_deref(), view.span().into())?;
 

--- a/crates/parser/src/evaluator/environment/math/equation.rs
+++ b/crates/parser/src/evaluator/environment/math/equation.rs
@@ -36,10 +36,8 @@ use crate::evaluator::{
 /// `[numbered=false]` と `[label=...]` を併用した場合は [`EvalError::LabelRequiresNumbering`] を返します
 pub(crate) fn equation(view: &EnvironmentView, evaluator: &mut Evaluator) -> Result<Vec<DocNode>, EvalError> {
   let opt_args = collect_environment_opt_args(view, &[("label", OptType::String), ("numbered", OptType::Bool)])?;
-  // label と numbered の 2 キーを取り出す。find_* は引数を消費するため bool 抽出には複製を渡す
-  // （任意引数は高々 2 要素で複製は軽量）
-  let numbered = find_bool(opt_args.clone(), "numbered").unwrap_or(true);
-  let label = find_string(opt_args, "label");
+  let numbered = find_bool(&opt_args, "numbered").unwrap_or(true);
+  let label = find_string(&opt_args, "label");
   if !view.args().is_empty() {
     return Err(EvalError::ExtraEnvironmentArgument {
       name: "equation".to_string(),

--- a/crates/parser/src/evaluator/environment/math/math_grid.rs
+++ b/crates/parser/src/evaluator/environment/math/math_grid.rs
@@ -122,7 +122,7 @@ pub(crate) fn evaluate_math_env(
 ) -> Result<Vec<DocNode>, EvalError> {
   // 許可する任意引数は [numbered] のみ。既定は採番あり
   let opt_args = collect_environment_opt_args(view, &[("numbered", OptType::Bool)])?;
-  let numbered = find_bool(opt_args, "numbered").unwrap_or(true);
+  let numbered = find_bool(&opt_args, "numbered").unwrap_or(true);
   if !view.args().is_empty() {
     return Err(EvalError::ExtraEnvironmentArgument {
       name: view.name().to_string(),

--- a/crates/parser/src/evaluator/environment/math/matrix.rs
+++ b/crates/parser/src/evaluator/environment/math/matrix.rs
@@ -31,7 +31,7 @@ use crate::evaluator::{
 /// 未知の任意引数キー・`delimiter` の不正値・位置引数の指定、本体のセル評価失敗時にエラーを返します
 pub(crate) fn matrix(view: &EnvironmentView, _evaluator: &mut Evaluator) -> Result<Vec<DocNode>, EvalError> {
   let opt_args = collect_environment_opt_args(view, &[("delimiter", OptType::String)])?;
-  let delimiter = match find_string(opt_args, "delimiter") {
+  let delimiter = match find_string(&opt_args, "delimiter") {
     Some(value) => MathDelimiter::from_opt_str(&value).ok_or_else(|| EvalError::InvalidOptArgValue {
       name: "matrix".to_string(),
       key: "delimiter".to_string(),

--- a/crates/parser/src/evaluator/opt_args.rs
+++ b/crates/parser/src/evaluator/opt_args.rs
@@ -67,33 +67,35 @@ pub(crate) enum OptValue {
 
 /// 収集済み任意引数から指定キーの文字列値を取り出す
 ///
-/// `[label=...]` のような単一の文字列キーを取り出す典型パターン用。
-/// キーが存在しない、または値が文字列型でない場合は `None` を返す。
-pub(crate) fn find_string(opt_args: Vec<(String, OptValue)>, key: &str) -> Option<String> {
-  return opt_args.into_iter().find_map(|(k, value)| match value {
-    OptValue::String(s) if k == key => Some(s),
+/// `[label=...]` のような文字列キーを取り出す。引数を借用するため、同じ `opt_args` から
+/// 複数のキー（例: `label` と `numbered`）を続けて抽出できる。キーが存在しない、または
+/// 値が文字列型でない場合は `None` を返す。
+pub(crate) fn find_string(opt_args: &[(String, OptValue)], key: &str) -> Option<String> {
+  return opt_args.iter().find_map(|(k, value)| match value {
+    OptValue::String(s) if k == key => Some(s.clone()),
     _ => None,
   });
 }
 
 /// 収集済み任意引数から指定キーの色値を取り出す
 ///
-/// `[color=#rrggbb]` のような単一の色キーを取り出す典型パターン用。
-/// キーが存在しない、または値が色型でない場合は `None` を返す。
-pub(crate) fn find_color(opt_args: Vec<(String, OptValue)>, key: &str) -> Option<Color> {
-  return opt_args.into_iter().find_map(|(k, value)| match value {
-    OptValue::Color(c) if k == key => Some(c),
+/// `[color=#rrggbb]` のような色キーを取り出す。引数を借用するため、同じ `opt_args` から
+/// 複数のキーを続けて抽出できる。キーが存在しない、または値が色型でない場合は `None` を返す。
+pub(crate) fn find_color(opt_args: &[(String, OptValue)], key: &str) -> Option<Color> {
+  return opt_args.iter().find_map(|(k, value)| match value {
+    OptValue::Color(c) if k == key => Some(*c),
     _ => None,
   });
 }
 
 /// 収集済み任意引数から指定キーの真偽値を取り出す
 ///
-/// `[numbered=false]` / `[breakable=false]` のような単一の bool キーを取り出す典型パターン用。
-/// キーが存在しない、または値が bool 型でない場合は `None` を返す。
-pub(crate) fn find_bool(opt_args: Vec<(String, OptValue)>, key: &str) -> Option<bool> {
-  return opt_args.into_iter().find_map(|(k, value)| match value {
-    OptValue::Bool(b) if k == key => Some(b),
+/// `[numbered=false]` / `[breakable=false]` のような bool キーを取り出す。引数を借用するため、
+/// 同じ `opt_args` から複数のキーを続けて抽出できる。キーが存在しない、または値が bool 型でない
+/// 場合は `None` を返す。
+pub(crate) fn find_bool(opt_args: &[(String, OptValue)], key: &str) -> Option<bool> {
+  return opt_args.iter().find_map(|(k, value)| match value {
+    OptValue::Bool(b) if k == key => Some(*b),
     _ => None,
   });
 }


### PR DESCRIPTION
## 概要

任意引数の値取り出しヘルパ `find_string` / `find_color` / `find_bool` を、引数を消費する `Vec<(String, OptValue)>` から借用 `&[(String, OptValue)]` に変える内部リファクタ。1 つの `opt_args` から複数キーを続けて抽出できるようになり、#109 で `equation` が入れた `opt_args.clone()` 回避策を撤去する。挙動は不変。

## 背景

`find_*` が `into_iter()` で `opt_args` を消費する設計は「1 ハンドラ = 1 キー抽出」を暗黙の前提にしていた。`equation` が `label` と `numbered` の 2 キーを必要としたため（#109）、bool 抽出に Vec の複製を渡す回避策が入っていた。借用に変えれば合成可能になり、今後 opt 引数が増えるハンドラでも同じ壁に当たらない。

## 変更内容

- **`crates/parser/src/evaluator/opt_args.rs`**
  - `find_string` / `find_color` / `find_bool` の引数を `&[(String, OptValue)]` に変更。`iter()` で走査し、マッチした値だけを返す（`String` は `clone`、`Color` / `bool` は `Copy` のため複製なし）。doc コメントも借用＝複数キー抽出可に更新。
- **呼び出し側（7 箇所）**: `find_*(opt_args, …)` → `find_*(&opt_args, …)`。`&Vec` は `&[..]` に Deref 強制される。
  - `command/headline.rs`・`command/inline.rs`・`command/link.rs`・`environment/figure.rs`・`environment/math/matrix.rs`・`environment/math/math_grid.rs`
  - `environment/math/equation.rs` は `opt_args.clone()` と釈明コメントを撤去して `&opt_args` に統一。

## テスト

挙動不変のリファクタにつき新規テストは追加せず、既存テストで担保。`cargo test`（pre-commit フックで全 workspace パス、parser 165 + 64 件）/ `cargo clippy --workspace`（警告ゼロ）/ `cargo +nightly fmt` 済み。

## 関連

- #109（`equation` の `[numbered=false]` 対応）で入った `opt_args.clone()` 回避策を撤去する後追いリファクタ。issue は伴わない（spec 不変の内部整理のため）。