### PR TITLE
数式: align/gather/split/multiline をラベル付け・\ref 参照に対応する

### DIFF
--- a/crates/document/src/block.rs
+++ b/crates/document/src/block.rs
@@ -155,6 +155,11 @@ pub enum DocNode {
   /// （`format` テンプレ適用済みの文字列）で、lowering 層が `EquationStyle::number_format` でさらに
   /// 装飾する。`[numbered=false]` で採番ありの環境を無採番にした場合は両方とも `None`。`kind` に応じて
   /// lowering 以降が列整列・区切り括弧・中央寄せを決める。
+  ///
+  /// ラベルの担い手も採番粒度に揃える。行ごと採番（`equation` / `align` / `gather`）は各行の
+  /// `MathRow::label`（`align` / `gather` は行末マーカー `\label{...}`、`equation` は `[label=...]`）が、
+  /// 環境単位採番（`split` / `multiline`）は環境の任意引数 `[label=...]` を受けるこの `label` フィールドが
+  /// 担う。lowering 層がいずれも `AnchorMark::Label` でブロック先頭の `\ref` 到達先に解決する。
   MathBlock {
     /// 環境種別
     kind: MathEnvKind,
@@ -163,6 +168,9 @@ pub enum DocNode {
     /// 環境全体に 1 つだけ付く通し番号（`split` / `multiline` 用、縦中央配置）。
     /// 行ごと採番の環境（`equation` / `align` / `gather`）や無採番では `None`
     number: Option<String>,
+    /// `\ref{eq:foo}` 解決用の環境単位ラベル（`split` / `multiline` の `[label=...]`）。
+    /// 行ごと採番の環境（ラベルは `MathRow::label` 側）や無採番では `None`
+    label: Option<String>,
   },
 
   /// 図環境（`\begin{figure}...\end{figure}`）

--- a/crates/lowering/src/lib.rs
+++ b/crates/lowering/src/lib.rs
@@ -242,7 +242,12 @@ fn lower_node_indexed(
       // ラベル付きブロックと同じ `AnchorMark::Label` でジャンプ先に解決させる。
       return Ok(vec![LayoutNode::Anchor(types::AnchorMark::Label(target.clone()))]);
     },
-    DocNode::MathBlock { kind, rows, number } => {
+    DocNode::MathBlock {
+      kind,
+      rows,
+      number,
+      label,
+    } => {
       let eq = &ctx.style.equation;
       let mut nodes = vec![
         LayoutNode::Vkern {
@@ -253,13 +258,15 @@ fn lower_node_indexed(
           length: eq.bottom_margin,
         },
       ];
-      // ラベル付き行（`equation` の `[label=...]` 等）の `\ref` 到達先アンカーを先頭に付ける。
-      // 複数行が同じブロック内にラベルを持つ場合も、いずれもブロック先頭座標に解決される。
+      // ラベル付き行（`equation` の `[label=...]`、`align` / `gather` の行末 `\label{...}`）の `\ref`
+      // 到達先アンカーを先頭に付ける。複数行がラベルを持つ場合も、いずれもブロック先頭座標に解決される。
       for row in rows {
         if let Some(label) = &row.label {
           nodes = with_label_anchor(Some(label), nodes);
         }
       }
+      // 環境単位ラベル（`split` / `multiline` の `[label=...]`）も同様にブロック先頭へ解決する
+      nodes = with_label_anchor(label.as_deref(), nodes);
       return Ok(nodes);
     },
     DocNode::Figure {
@@ -330,6 +337,8 @@ mod tests {
         label: label.map(str::to_string),
       }],
       number: None,
+      // equation はラベルを行側（`MathRow::label`）に持つため、環境単位ラベルは None
+      label: None,
     };
   }
 

--- a/crates/parser/src/evaluator/environment/math/align.rs
+++ b/crates/parser/src/evaluator/environment/math/align.rs
@@ -192,8 +192,9 @@ mod tests {
   }
 
   #[test]
-  fn align_rejects_unknown_opt_args() {
-    // Arrange — align は `[numbered]` のみ許可。`[label=...]` は未知キーエラー
+  fn align_rejects_env_level_label_opt_arg() {
+    // Arrange — align は行ごと採番。ラベルは行末マーカー `\label{...}` で付けるため、環境レベルの
+    // `[label=...]` は受け付けない（スキーマ外の未知キーエラー）
     let arena = Bump::new();
     let source = r"\begin{align}[label=eq:foo]a &= b\end{align}";
     let cst = parse(source, &arena).unwrap();
@@ -204,6 +205,86 @@ mod tests {
 
     // Assert
     assert!(matches!(result, Err(EvalError::UnknownOptArgKey { ref key, .. }) if key == "label"));
+  }
+
+  #[test]
+  fn align_row_label_captures_label_and_keeps_numbering() {
+    // Arrange — 1 行目の行末に `\label{...}` を置くと、その行に番号とラベルが付く
+    let arena = Bump::new();
+    let source = r"\begin{align}a &= b \label{eq:foo} \\ c &= d\end{align}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::new(&style_with_plain_equation_format());
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst).unwrap();
+
+    // Assert — 1 行目: ラベルあり・番号 1、2 行目: ラベルなし・番号 2（通し番号は連続）
+    let rows = rows_of(&result);
+    assert_eq!(rows.len(), 2, "2 行に分割される: {rows:?}");
+    assert_eq!(rows[0].label.as_deref(), Some("eq:foo"));
+    assert_eq!(rows[0].number.as_deref(), Some("1"));
+    assert!(rows[1].label.is_none(), "2 行目はラベルなし: {:?}", rows[1].label);
+    assert_eq!(rows[1].number.as_deref(), Some("2"));
+  }
+
+  #[test]
+  fn align_row_label_on_notag_row_errors() {
+    // Arrange — \notag 行（無採番）にラベルは付けられない（参照番号が無いため）
+    let arena = Bump::new();
+    let source = r"\begin{align}a &= b \notag \label{eq:x}\end{align}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::default();
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst);
+
+    // Assert
+    assert!(matches!(result, Err(EvalError::LabelRequiresNumbering { ref name, .. }) if name == "align"));
+  }
+
+  #[test]
+  fn align_row_label_with_numbered_false_errors() {
+    // Arrange — [numbered=false]（全行無採番）の行ラベルも参照番号が無いためエラー
+    let arena = Bump::new();
+    let source = r"\begin{align}[numbered=false]a &= b \label{eq:x}\end{align}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::default();
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst);
+
+    // Assert
+    assert!(matches!(result, Err(EvalError::LabelRequiresNumbering { ref name, .. }) if name == "align"));
+  }
+
+  #[test]
+  fn align_row_label_not_at_row_end_errors() {
+    // Arrange — \label の後ろに列・内容が続く（行末でない）とエラー
+    let arena = Bump::new();
+    let source = r"\begin{align}a \label{eq:x} &= b\end{align}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::default();
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst);
+
+    // Assert
+    assert!(matches!(result, Err(EvalError::RowLabelNotAtRowEnd { .. })));
+  }
+
+  #[test]
+  fn align_duplicate_row_label_errors() {
+    // Arrange — 同名の行ラベルを 2 行に付けると重複エラー
+    let arena = Bump::new();
+    let source = r"\begin{align}a &= b \label{eq:x} \\ c &= d \label{eq:x}\end{align}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::new(&style_with_plain_equation_format());
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst);
+
+    // Assert
+    assert!(matches!(result, Err(EvalError::DuplicateLabel { ref label, .. }) if label == "eq:x"));
   }
 
   #[test]

--- a/crates/parser/src/evaluator/environment/math/cases.rs
+++ b/crates/parser/src/evaluator/environment/math/cases.rs
@@ -41,7 +41,7 @@ pub(crate) fn cases(view: &EnvironmentView, _evaluator: &mut Evaluator) -> Resul
         allow_row_breaks: true,
         allow_column_breaks: true,
       },
-      // cases は非採番のため `\notag` は不可
+      // cases は非採番のため行末マーカー `\notag` / `\label` は不可
       false,
     )?,
     None => Vec::new(),
@@ -59,6 +59,8 @@ pub(crate) fn cases(view: &EnvironmentView, _evaluator: &mut Evaluator) -> Resul
     kind: MathEnvKind::Cases,
     rows,
     number: None,
+    // cases は非採番のため参照対象外
+    label: None,
   }]);
 }
 
@@ -87,7 +89,10 @@ mod tests {
   }
 
   fn rows_of(result: &[DocNode]) -> &[document::MathRow] {
-    let DocNode::MathBlock { kind, rows, number } = &result[0] else {
+    let DocNode::MathBlock {
+      kind, rows, number, ..
+    } = &result[0]
+    else {
       panic!("MathBlock が期待されます: {:?}", result[0]);
     };
     assert_eq!(*kind, MathEnvKind::Cases, "cases は MathEnvKind::Cases");

--- a/crates/parser/src/evaluator/environment/math/equation.rs
+++ b/crates/parser/src/evaluator/environment/math/equation.rs
@@ -71,7 +71,8 @@ pub(crate) fn equation(view: &EnvironmentView, evaluator: &mut Evaluator) -> Res
         allow_row_breaks: false,
         allow_column_breaks: false,
       };
-      // equation は行ごと採番ではないため `\notag` は不可（無採番にするなら `[numbered=false]`）
+      // equation は行ごと採番ではないため行末マーカー `\notag` / `\label` は不可
+      // （無採番なら `[numbered=false]`、ラベルは `[label=...]`）
       let grid = evaluate_grid(source, body_node, &spec, false)?;
       // 分割を許していないので必ず 1 行。その行のセル列（1 セル）を取り出す
       grid.into_iter().next().map_or_else(|| vec![Vec::new()], |row| row.cells)
@@ -87,8 +88,9 @@ pub(crate) fn equation(view: &EnvironmentView, evaluator: &mut Evaluator) -> Res
   return Ok(vec![DocNode::MathBlock {
     kind: MathEnvKind::Equation,
     rows: vec![row],
-    // equation は行ごと採番（`row.number`）。環境全体の番号は使わない
+    // equation は行ごと採番（`row.number`）。環境全体の番号・ラベルは使わない（ラベルは `row.label`）
     number: None,
+    label: None,
   }]);
 }
 
@@ -345,5 +347,20 @@ mod tests {
 
     // Assert
     assert!(matches!(result, Err(EvalError::NotagNotSupported { .. })));
+  }
+
+  #[test]
+  fn equation_rejects_row_label_marker() {
+    // Arrange — equation は行末マーカー `\label{...}` を受け付けない（ラベルは `[label=...]` を使う）
+    let arena = Bump::new();
+    let source = r"\begin{equation}a \label{eq:x}\end{equation}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::default();
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst);
+
+    // Assert
+    assert!(matches!(result, Err(EvalError::RowLabelNotSupported { .. })));
   }
 }

--- a/crates/parser/src/evaluator/environment/math/gather.rs
+++ b/crates/parser/src/evaluator/environment/math/gather.rs
@@ -153,4 +153,24 @@ mod tests {
     // Assert
     assert!(matches!(result, Err(EvalError::NotagNotAtRowEnd { .. })));
   }
+
+  #[test]
+  fn gather_row_label_captures_label_and_keeps_numbering() {
+    // Arrange — gather でも行末マーカー `\label{...}` でその行にラベルを付けられる
+    let arena = Bump::new();
+    let source = r"\begin{gather}a = b \label{eq:g} \\ c = d\end{gather}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::new(&style_with_plain_equation_format());
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst).unwrap();
+
+    // Assert — 1 行目: ラベルあり・番号 1、2 行目: ラベルなし・番号 2
+    let rows = rows_of(&result);
+    assert_eq!(rows.len(), 2, "2 行に分割される: {rows:?}");
+    assert_eq!(rows[0].label.as_deref(), Some("eq:g"));
+    assert_eq!(rows[0].number.as_deref(), Some("1"));
+    assert!(rows[1].label.is_none(), "2 行目はラベルなし: {:?}", rows[1].label);
+    assert_eq!(rows[1].number.as_deref(), Some("2"));
+  }
 }

--- a/crates/parser/src/evaluator/environment/math/math_grid.rs
+++ b/crates/parser/src/evaluator/environment/math/math_grid.rs
@@ -16,7 +16,7 @@ use miette::SourceSpan;
 use read_style::CounterName;
 use syntax::{
   SyntaxKind,
-  ast::{CommandView, EnvironmentView},
+  ast::{CommandView, EnvironmentView, extract_text_content},
   green::{GreenElement, GreenNode},
   token::TokenKind,
 };
@@ -24,7 +24,7 @@ use syntax::{
 use crate::evaluator::{
   EvalError, Evaluator,
   math::evaluate_math_elements,
-  opt_args::{OptType, collect_environment_opt_args, find_bool},
+  opt_args::{OptType, collect_environment_opt_args, find_bool, find_string},
 };
 
 /// グリッド分割の許可設定（環境種別ごと）
@@ -42,39 +42,47 @@ pub(crate) struct GridSpec {
 ///
 /// `cells` は `&` で分割した各列の `MathNode` 列。`notag_span` はその行に行末マーカー `\notag` が
 /// 付いていた場合の `\notag` のソース位置（`None` は採番対象）。行ごと採番の `align` / `gather` では
-/// `notag_span.is_some()` の行を無採番にする。
+/// `notag_span.is_some()` の行を無採番にする。`label` / `label_span` は行末マーカー `\label{...}` で
+/// 付与された行ラベルとその位置（`None` は参照対象外）。
 #[derive(Debug)]
 pub(crate) struct GridRow {
   /// 列（`&` 区切り）。各列は数式ノード列
   pub cells: Vec<Vec<MathNode>>,
   /// 行末マーカー `\notag` の位置（`None` は採番する）
   pub notag_span: Option<SourceSpan>,
+  /// 行末マーカー `\label{...}` で付与された行ラベル（`None` は参照対象外）
+  pub label: Option<String>,
+  /// 行末マーカー `\label` のソース位置（重複・無採番診断用。`label` が `Some` なら `Some`）
+  pub label_span: Option<SourceSpan>,
 }
 
 /// 数式環境本体を行 × 列のグリッドに分割して評価する
 ///
-/// 戻り値は [`GridRow`] のリスト。各行はセル（列）のリストと行末マーカー `\notag` の有無
-/// （`notag_span`）を持つ。`equation` のように分割を許さない環境では常に「1 行 1 セル」を返す
-/// （本体が空でも 1 行 1 空セル）。
+/// 戻り値は [`GridRow`] のリスト。各行はセル（列）のリストと行末マーカー（`\notag` / `\label`）の
+/// 情報を持つ。`equation` のように分割を許さない環境では常に「1 行 1 セル」を返す（本体が空でも
+/// 1 行 1 空セル）。
 ///
-/// `notag_allowed` が `true`（行ごと採番の `align` / `gather`）のときのみ行末の `\notag` を受理し、
-/// その行の `notag_span` を立てる（マーカー自体はセルに残さないため後段の数式評価には現れない）。
+/// `row_markers_allowed` が `true`（行ごと採番の `align` / `gather`）のときのみ行末マーカー
+/// `\notag`（その行を無採番にする）と `\label{...}`（その行にラベルを付ける）を受理し、行の
+/// `notag_span` / `label` を立てる（マーカー自体はセルに残さないため後段の数式評価には現れない）。
 ///
 /// # Errors
 ///
-/// 許可していない区切りトークン（`\\` / `&`）の出現、`\notag` の不正な使用（非許可環境＝
-/// [`EvalError::NotagNotSupported`]、行末以外・引数付き・1 行に複数＝[`EvalError::NotagNotAtRowEnd`]）、
-/// セル内の数式評価失敗時にエラーを返す。
+/// 許可していない区切りトークン（`\\` / `&`）の出現、行末マーカーの不正な使用（非許可環境＝
+/// [`EvalError::NotagNotSupported`] / [`EvalError::RowLabelNotSupported`]、行末以外・引数不正・1 行に
+/// 複数＝[`EvalError::NotagNotAtRowEnd`] / [`EvalError::RowLabelNotAtRowEnd`]）、セル内の数式評価失敗時に
+/// エラーを返す。
 pub(crate) fn evaluate_grid(
   source: &str,
   body: &GreenNode,
   spec: &GridSpec,
-  notag_allowed: bool,
+  row_markers_allowed: bool,
 ) -> Result<Vec<GridRow>, EvalError> {
   let mut rows: Vec<GridRow> = Vec::new();
   let mut current_row: Vec<Vec<MathNode>> = Vec::new();
   let mut current_cell: Vec<GreenElement> = Vec::new();
   let mut current_notag: Option<SourceSpan> = None;
+  let mut current_label: Option<(String, SourceSpan)> = None;
 
   for child in body.children {
     if let GreenElement::Token(token) = child {
@@ -86,9 +94,12 @@ pub(crate) fn evaluate_grid(
               span: token.span.into(),
             });
           }
-          // `\notag` の後ろに列が続くなら、`\notag` は行末になく不正
+          // 行末マーカーの後ろに列が続くなら、マーカーは行末になく不正
           if let Some(span) = current_notag {
             return Err(EvalError::NotagNotAtRowEnd { span });
+          }
+          if let Some((_, span)) = &current_label {
+            return Err(EvalError::RowLabelNotAtRowEnd { span: *span });
           }
           current_row.push(evaluate_math_elements(source, &current_cell)?);
           current_cell.clear();
@@ -103,9 +114,12 @@ pub(crate) fn evaluate_grid(
           }
           current_row.push(evaluate_math_elements(source, &current_cell)?);
           current_cell.clear();
+          let (label, label_span) = take_row_label(&mut current_label);
           rows.push(GridRow {
             cells: std::mem::take(&mut current_row),
             notag_span: current_notag.take(),
+            label,
+            label_span,
           });
           continue;
         },
@@ -113,14 +127,14 @@ pub(crate) fn evaluate_grid(
       }
     }
 
-    // 行末マーカー `\notag` の検出（CommandCall ノード）
+    // 行末マーカー `\notag` / `\label{...}` の検出（CommandCall ノード）
     if let GreenElement::Node(node) = *child
       && node.kind == SyntaxKind::CommandCall
     {
       let view = CommandView::new(node, source);
       if view.name() == "notag" {
         let span: SourceSpan = node.span.into();
-        if !notag_allowed {
+        if !row_markers_allowed {
           return Err(EvalError::NotagNotSupported { span });
         }
         // `\notag` は引数を取らない（`\notag{...}` が後続の中身を飲み込むのを防ぐ）
@@ -134,13 +148,34 @@ pub(crate) fn evaluate_grid(
         current_notag = Some(span);
         continue;
       }
+      if view.name() == "label" {
+        let span: SourceSpan = node.span.into();
+        if !row_markers_allowed {
+          return Err(EvalError::RowLabelNotSupported { span });
+        }
+        // `\label` は必須引数 1 個（ラベル名）のみ。引数過不足・任意引数付きは不正
+        if view.args_count() != 1 || view.opt_args_count() > 0 {
+          return Err(EvalError::RowLabelNotAtRowEnd { span });
+        }
+        // 1 行に `\label` は 1 つだけ
+        if current_label.is_some() {
+          return Err(EvalError::RowLabelNotAtRowEnd { span });
+        }
+        let first_arg = view.first_arg().ok_or(EvalError::RowLabelNotAtRowEnd { span })?;
+        let label = extract_text_content(source, first_arg).trim().to_string();
+        current_label = Some((label, span));
+        continue;
+      }
     }
 
-    // `\notag` の後ろに意味のある要素が来たら行末ではない（末尾空白等のトリビアは許容）
-    if let Some(span) = current_notag
-      && !is_trivia_element(child)
-    {
-      return Err(EvalError::NotagNotAtRowEnd { span });
+    // 行末マーカーの後ろに意味のある要素が来たら行末ではない（末尾空白等のトリビアは許容）
+    if !is_trivia_element(child) {
+      if let Some(span) = current_notag {
+        return Err(EvalError::NotagNotAtRowEnd { span });
+      }
+      if let Some((_, span)) = &current_label {
+        return Err(EvalError::RowLabelNotAtRowEnd { span: *span });
+      }
     }
 
     current_cell.push(*child);
@@ -148,11 +183,24 @@ pub(crate) fn evaluate_grid(
 
   // 末尾のセル・行を確定する（行区切りで終わっていなければ最後の行を 1 つ積む）
   current_row.push(evaluate_math_elements(source, &current_cell)?);
+  let (label, label_span) = take_row_label(&mut current_label);
   rows.push(GridRow {
     cells: current_row,
     notag_span: current_notag,
+    label,
+    label_span,
   });
   return Ok(rows);
+}
+
+/// 行末マーカー `\label{...}` の蓄積を行の `(label, label_span)` に取り出すヘルパ
+///
+/// `current_label` を消費し、ラベル文字列とその位置をそれぞれの `Option` に分解して返す。
+fn take_row_label(current_label: &mut Option<(String, SourceSpan)>) -> (Option<String>, Option<SourceSpan>) {
+  return match current_label.take() {
+    Some((label, span)) => (Some(label), Some(span)),
+    None => (None, None),
+  };
 }
 
 /// 採番の粒度
@@ -168,14 +216,19 @@ pub(crate) enum NumberingMode {
 
 /// `align` / `gather` / `split` / `multiline` の共通評価本体
 ///
-/// 任意引数 `[numbered]`（既定 `true`）のみを許可し、本体を `spec` に従って `\\`×`&` のグリッドへ
-/// 分割（[`evaluate_grid`]）したのち末尾の空行を除去し、`mode` に応じて採番した `DocNode::MathBlock`
-/// を返す。`numbered == false` のときは採番を一切行わない（採番ありの環境を無採番にする）。
+/// 任意引数 `[numbered]`（既定 `true`）を許可し、環境単位採番（`SingleEnv` = `split` / `multiline`）では
+/// 加えて `[label=...]` を受理する。本体を `spec` に従って `\\`×`&` のグリッドへ分割（[`evaluate_grid`]）
+/// したのち末尾の空行を除去し、`mode` に応じて採番した `DocNode::MathBlock` を返す。`numbered == false`
+/// のときは採番を一切行わない（採番ありの環境を無採番にする）。
+///
+/// ラベルは採番粒度に揃える。`PerRow`（`align` / `gather`）は行末マーカー `\label{...}` をその行の
+/// `MathRow::label` に、`SingleEnv`（`split` / `multiline`）は環境の `[label=...]` を `MathBlock::label` に
+/// 載せる。いずれも無採番の行/環境にラベルは付けられない（参照番号が無いため [`EvalError::LabelRequiresNumbering`]）。
 ///
 /// # Errors
 ///
-/// 未知の任意引数キー（`numbered` 以外）・位置引数の指定、本体のセル評価や許可しない区切りトークンの
-/// 出現時にエラーを返す。
+/// 未知の任意引数キー・位置引数の指定、本体のセル評価や許可しない区切りトークンの出現、無採番への
+/// ラベル付与・重複ラベル時にエラーを返す。
 pub(crate) fn evaluate_math_env(
   view: &EnvironmentView,
   evaluator: &mut Evaluator,
@@ -183,31 +236,49 @@ pub(crate) fn evaluate_math_env(
   spec: &GridSpec,
   mode: &NumberingMode,
 ) -> Result<Vec<DocNode>, EvalError> {
-  // 許可する任意引数は [numbered] のみ。既定は採番あり
-  let opt_args = collect_environment_opt_args(view, &[("numbered", OptType::Bool)])?;
+  // 環境単位ラベル `[label=...]` は環境全体に 1 番号を振る `SingleEnv`（split / multiline）でのみ受理する。
+  // 行ごと採番（`PerRow` = align / gather）の行単位ラベルは行末マーカー `\label{...}` で指定する。
+  let allow_env_label = matches!(mode, NumberingMode::SingleEnv);
+  let schema: &[(&str, OptType)] = if allow_env_label {
+    &[("label", OptType::String), ("numbered", OptType::Bool)]
+  } else {
+    &[("numbered", OptType::Bool)]
+  };
+  let opt_args = collect_environment_opt_args(view, schema)?;
   let numbered = find_bool(&opt_args, "numbered").unwrap_or(true);
+  let env_label = find_string(&opt_args, "label");
   if !view.args().is_empty() {
     return Err(EvalError::ExtraEnvironmentArgument {
       name: view.name().to_string(),
       span: view.span().into(),
     });
   }
+  // 無採番の環境は参照番号を持たないため、環境単位ラベルとの併用を禁じる（equation と同じ規則）
+  if !numbered && env_label.is_some() {
+    return Err(EvalError::LabelRequiresNumbering {
+      name: view.name().to_string(),
+      span: view.span().into(),
+    });
+  }
 
-  // 行末マーカー `\notag` は行ごと採番（`PerRow`）の環境でのみ意味を持つ
-  let notag_allowed = matches!(mode, NumberingMode::PerRow);
+  // 行末マーカー `\notag` / `\label` は行ごと採番（`PerRow`）の環境でのみ意味を持つ
+  let row_markers_allowed = matches!(mode, NumberingMode::PerRow);
   let source = view.source();
   let mut grid = match view.body() {
-    Some(body_node) => evaluate_grid(source, body_node, spec, notag_allowed)?,
+    Some(body_node) => evaluate_grid(source, body_node, spec, row_markers_allowed)?,
     None => Vec::new(),
   };
   // 行末の `\\` は分割器が末尾に空白だけの行を 1 つ生むため、採番前に除去する。
-  // 中身が空なのに `\notag` だけ付いた末尾行（例 `a \\ \notag`）は行末に式がないためエラーにする。
+  // 中身が空なのにマーカー（`\notag` / `\label`）だけ付いた末尾行は行末に式がないためエラーにする。
   while let Some(last) = grid.last() {
     if !is_blank_row(&last.cells) {
       break;
     }
     if let Some(span) = last.notag_span {
       return Err(EvalError::NotagNotAtRowEnd { span });
+    }
+    if let Some(span) = last.label_span {
+      return Err(EvalError::RowLabelNotAtRowEnd { span });
     }
     grid.pop();
   }
@@ -221,21 +292,42 @@ pub(crate) fn evaluate_math_env(
   let rows: Vec<MathRow> = match mode {
     NumberingMode::PerRow => grid
       .into_iter()
-      .map(|row| {
+      .map(|row| -> Result<MathRow, EvalError> {
         // `\notag` 行（`notag_span` あり）はカウンタを消費せず無採番にする
-        let number =
-          (numbered && row.notag_span.is_none()).then(|| evaluator.registry.increment(CounterName::Equation));
-        return MathRow {
+        let numbered_row = numbered && row.notag_span.is_none();
+        // 無採番の行に行ラベルは付けられない（参照番号が無いため）
+        if let Some(span) = row.label_span
+          && !numbered_row
+        {
+          return Err(EvalError::LabelRequiresNumbering {
+            name: view.name().to_string(),
+            span,
+          });
+        }
+        let number = if numbered_row {
+          Some(evaluator.registry.increment_with_label(
+            CounterName::Equation,
+            row.label.as_deref(),
+            row.label_span.unwrap_or_else(|| view.span().into()),
+          )?)
+        } else {
+          None
+        };
+        return Ok(MathRow {
           cells: row.cells,
           number,
-          label: None,
-        };
+          label: row.label,
+        });
       })
-      .collect(),
+      .collect::<Result<Vec<MathRow>, EvalError>>()?,
     NumberingMode::SingleEnv => {
       // 行は無採番。環境全体に 1 つだけ（空ブロックには採番しない）
       if numbered && !grid.is_empty() {
-        env_number = Some(evaluator.registry.increment(CounterName::Equation));
+        env_number = Some(evaluator.registry.increment_with_label(
+          CounterName::Equation,
+          env_label.as_deref(),
+          view.span().into(),
+        )?);
       }
       grid
         .into_iter()
@@ -248,10 +340,13 @@ pub(crate) fn evaluate_math_env(
     },
   };
 
+  // 環境単位ラベルは採番できた場合のみ持たせる（無採番・空ブロックはダングリングアンカーを避け None）
+  let block_label = env_number.as_ref().and(env_label);
   return Ok(vec![DocNode::MathBlock {
     kind,
     rows,
     number: env_number,
+    label: block_label,
   }]);
 }
 

--- a/crates/parser/src/evaluator/environment/math/matrix.rs
+++ b/crates/parser/src/evaluator/environment/math/matrix.rs
@@ -56,7 +56,7 @@ pub(crate) fn matrix(view: &EnvironmentView, _evaluator: &mut Evaluator) -> Resu
         allow_row_breaks: true,
         allow_column_breaks: true,
       },
-      // matrix は非採番のため `\notag` は不可
+      // matrix は非採番のため行末マーカー `\notag` / `\label` は不可
       false,
     )?,
     None => Vec::new(),
@@ -67,6 +67,8 @@ pub(crate) fn matrix(view: &EnvironmentView, _evaluator: &mut Evaluator) -> Resu
     kind: MathEnvKind::Matrix { delimiter },
     rows,
     number: None,
+    // matrix は非採番のため参照対象外
+    label: None,
   }]);
 }
 
@@ -96,7 +98,10 @@ mod tests {
 
   /// 結果の最初の `MathBlock` の `(delimiter, rows)` を取り出すヘルパ（kind が Matrix であることも検証）
   fn matrix_of(result: &[DocNode]) -> (MathDelimiter, &[document::MathRow]) {
-    let DocNode::MathBlock { kind, rows, number } = &result[0] else {
+    let DocNode::MathBlock {
+      kind, rows, number, ..
+    } = &result[0]
+    else {
       panic!("MathBlock が期待されます: {:?}", result[0]);
     };
     assert!(number.is_none(), "matrix は非採番（環境番号なし）: {number:?}");

--- a/crates/parser/src/evaluator/environment/math/multiline.rs
+++ b/crates/parser/src/evaluator/environment/math/multiline.rs
@@ -65,7 +65,10 @@ mod tests {
   }
 
   fn block_of(result: &[DocNode]) -> (&[document::MathRow], Option<&str>) {
-    let DocNode::MathBlock { kind, rows, number } = &result[0] else {
+    let DocNode::MathBlock {
+      kind, rows, number, ..
+    } = &result[0]
+    else {
       panic!("MathBlock が期待されます: {:?}", result[0]);
     };
     assert_eq!(*kind, MathEnvKind::Multiline, "multiline は MathEnvKind::Multiline");
@@ -120,5 +123,39 @@ mod tests {
     // Assert
     let (_, env_number) = block_of(&result);
     assert_eq!(env_number, None, "無採番のはず");
+  }
+
+  #[test]
+  fn multiline_with_label_captures_block_label() {
+    // Arrange — `[label=...]` で環境単位ラベルが付き、環境全体に番号が付く
+    let arena = Bump::new();
+    let source = r"\begin{multiline}[label=eq:m]a + b \\ + c\end{multiline}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::new(&style_with_plain_equation_format());
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst).unwrap();
+
+    // Assert — MathBlock.label と env number が両方付く
+    let DocNode::MathBlock { number, label, .. } = &result[0] else {
+      panic!("MathBlock が期待されます: {:?}", result[0]);
+    };
+    assert_eq!(label.as_deref(), Some("eq:m"), "環境単位ラベルが付く");
+    assert_eq!(number.as_deref(), Some("1"), "環境全体に 1 つの番号");
+  }
+
+  #[test]
+  fn multiline_rejects_row_label_marker() {
+    // Arrange — multiline は環境単位採番。行末マーカー `\label{...}` は使えない（`[label=...]` を使う）
+    let arena = Bump::new();
+    let source = r"\begin{multiline}a + b \label{eq:m} \\ + c\end{multiline}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::default();
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst);
+
+    // Assert
+    assert!(matches!(result, Err(EvalError::RowLabelNotSupported { .. })));
   }
 }

--- a/crates/parser/src/evaluator/environment/math/split.rs
+++ b/crates/parser/src/evaluator/environment/math/split.rs
@@ -63,7 +63,10 @@ mod tests {
 
   /// 最初の `DocNode::MathBlock`（`Split`）を分解して (`rows`, `env_number`) を返す
   fn block_of(result: &[DocNode]) -> (&[document::MathRow], Option<&str>) {
-    let DocNode::MathBlock { kind, rows, number } = &result[0] else {
+    let DocNode::MathBlock {
+      kind, rows, number, ..
+    } = &result[0]
+    else {
       panic!("MathBlock が期待されます: {:?}", result[0]);
     };
     assert_eq!(*kind, MathEnvKind::Split, "split は MathEnvKind::Split");
@@ -123,5 +126,61 @@ mod tests {
     let (rows, env_number) = block_of(&result);
     assert!(rows.iter().all(|r| r.number.is_none()));
     assert_eq!(env_number, None, "無採番のはず");
+  }
+
+  #[test]
+  fn split_with_label_captures_block_label() {
+    // Arrange — `[label=...]` で環境単位ラベルが付き、環境全体に番号が付く
+    let arena = Bump::new();
+    let source = r"\begin{split}[label=eq:s]a &= b \\ &= c\end{split}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::new(&style_with_plain_equation_format());
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst).unwrap();
+
+    // Assert — MathBlock.label と env number が両方付く（行は無採番）
+    let DocNode::MathBlock {
+      rows,
+      number,
+      label,
+      ..
+    } = &result[0]
+    else {
+      panic!("MathBlock が期待されます: {:?}", result[0]);
+    };
+    assert_eq!(label.as_deref(), Some("eq:s"), "環境単位ラベルが付く");
+    assert_eq!(number.as_deref(), Some("1"), "環境全体に 1 つの番号");
+    assert!(rows.iter().all(|r| r.number.is_none()), "行は無採番: {rows:?}");
+  }
+
+  #[test]
+  fn split_numbered_false_with_label_errors() {
+    // Arrange — 無採番の環境にラベルを付けるとエラー（参照番号が存在しないため）
+    let arena = Bump::new();
+    let source = r"\begin{split}[numbered=false][label=eq:s]a &= b\end{split}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::default();
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst);
+
+    // Assert
+    assert!(matches!(result, Err(EvalError::LabelRequiresNumbering { ref name, .. }) if name == "split"));
+  }
+
+  #[test]
+  fn split_rejects_row_label_marker() {
+    // Arrange — split は環境単位採番。行末マーカー `\label{...}` は使えない（`[label=...]` を使う）
+    let arena = Bump::new();
+    let source = r"\begin{split}a &= b \label{eq:s}\end{split}";
+    let cst = parse(source, &arena).unwrap();
+    let mut evaluator = Evaluator::default();
+
+    // Act
+    let result = evaluator.evaluate_children(source, cst);
+
+    // Assert
+    assert!(matches!(result, Err(EvalError::RowLabelNotSupported { .. })));
   }
 }

--- a/crates/parser/src/evaluator/error.rs
+++ b/crates/parser/src/evaluator/error.rs
@@ -314,6 +314,40 @@ pub enum EvalError {
     span: SourceSpan,
   },
 
+  /// 行ラベルマーカー `\label` が行ごと採番でない数式環境に現れた場合
+  ///
+  /// `\label{...}` は行ごとに採番する `align` / `gather` の行末でのみ意味を持つ。`equation` /
+  /// `split` / `multiline` は環境の任意引数 `[label=...]` でラベルを付け、`cases` / `matrix` は非採番なので
+  /// 参照対象がない。
+  #[error("行ラベル \\label はこの数式環境では使用できません")]
+  #[diagnostic(
+    code(parser::eval::row_label_not_supported),
+    help(
+      "\\label は align / gather の行末でのみ使えます。equation / split / multiline は [label=...] を使ってください。"
+    )
+  )]
+  RowLabelNotSupported {
+    /// `\label` のソース位置
+    #[label("この環境では行ラベル \\label を使えません")]
+    span: SourceSpan,
+  },
+
+  /// 行ラベルマーカー `\label` が行末以外に置かれた・引数が不正だった場合
+  ///
+  /// `\label{name}` は「その行にラベルを付ける」マーカーで、行の末尾（`\\` または `\end` の直前）にのみ
+  /// 置ける。行の途中・列区切り `&` の前・1 行に複数・必須引数 1 個以外（`\label` / `\label{a}{b}`）・
+  /// 任意引数付きはエラーにする。
+  #[error("\\label は行の末尾に、ラベル名 1 個の引数付きで置けます")]
+  #[diagnostic(
+    code(parser::eval::row_label_not_at_row_end),
+    help("\\label は各行の末尾（\\\\ または \\end の直前）に 1 つだけ、`\\label{{name}}` の形で置いてください。")
+  )]
+  RowLabelNotAtRowEnd {
+    /// `\label` のソース位置
+    #[label("この \\label は行末にないか、引数が不正です")]
+    span: SourceSpan,
+  },
+
   /// 環境の本体に許可されていないコマンドが出現した場合
   #[error("環境 {env} 内で許可されていないコマンドです: \\{name}")]
   #[diagnostic(

--- a/crates/parser/tests/evaluate.rs
+++ b/crates/parser/tests/evaluate.rs
@@ -226,6 +226,57 @@ fn evaluate_equation_with_label_then_ref_resolves_with_parens() {
 }
 
 #[test]
+fn evaluate_align_row_label_then_ref_resolves_with_parens() {
+  // align は行ごと採番。行末マーカー `\label{...}` を付けた行の番号を `\ref` で参照できる。
+  // `\chapter` で chapter を 1 にし、align の 1 行目に `\label` を付けると "(1.1)" に解決する。
+  let source = r"\chapter{C}\begin{align}a &= b \label{eq:a} \\ c &= d\end{align}See \ref{eq:a}.";
+  let result = evaluate_source(source);
+  let para = result
+    .iter()
+    .find_map(|n| {
+      if let DocNode::Paragraph(i) = n {
+        Some(i)
+      } else {
+        None
+      }
+    })
+    .expect("Paragraph が含まれるべき");
+  let ref_node = para
+    .iter()
+    .find_map(|n| match n {
+      InlineNode::Ref { number, .. } => Some(number.clone()),
+      _ => None,
+    })
+    .expect("Ref ノードが含まれるべき");
+  assert_eq!(ref_node.as_deref(), Some("(1.1)"), "1 行目の番号 1.1 が参照される");
+}
+
+#[test]
+fn evaluate_split_env_label_then_ref_resolves_with_parens() {
+  // split は環境単位採番。`[label=...]` で環境全体の番号を `\ref` で参照できる。
+  let source = r"\chapter{C}\begin{split}[label=eq:s]a &= b \\ &= c\end{split}See \ref{eq:s}.";
+  let result = evaluate_source(source);
+  let para = result
+    .iter()
+    .find_map(|n| {
+      if let DocNode::Paragraph(i) = n {
+        Some(i)
+      } else {
+        None
+      }
+    })
+    .expect("Paragraph が含まれるべき");
+  let ref_node = para
+    .iter()
+    .find_map(|n| match n {
+      InlineNode::Ref { number, .. } => Some(number.clone()),
+      _ => None,
+    })
+    .expect("Ref ノードが含まれるべき");
+  assert_eq!(ref_node.as_deref(), Some("(1.1)"), "環境単位の番号 1.1 が参照される");
+}
+
+#[test]
 fn evaluate_unknown_ref_returns_unknown_label_error() {
   let err = evaluate_error(r"\ref{nope}");
   assert!(matches!(err, EvalError::UnknownLabel { ref label, .. } if label == "nope"));

--- a/tests/text/align.sei
+++ b/tests/text/align.sei
@@ -34,3 +34,15 @@ a &= b \\
 c &= d \notag \\
 e &= f
 \end{align}
+
+\section{行へのラベル付けと参照}
+
+align では行末に label マーカーを置くと、その行に番号とラベルが付き、本文から参照できる。
+
+\begin{align}
+a &= b \\
+c &= d \label{eq:align-cd} \\
+e &= f
+\end{align}
+
+2 行目の式は \ref{eq:align-cd} で参照できる。

--- a/tests/text/gather.sei
+++ b/tests/text/gather.sei
@@ -16,3 +16,14 @@ numbered=false で採番を抑制できる。
 p = q \\
 r = s
 \end{gather}
+
+\section{行へのラベル付けと参照}
+
+gather でも行末の label マーカーでその行に番号とラベルが付き、本文から参照できる。
+
+\begin{gather}
+p = q \label{eq:gather-pq} \\
+r = s
+\end{gather}
+
+1 行目の式は \ref{eq:gather-pq} で参照できる。

--- a/tests/text/multiline.sei
+++ b/tests/text/multiline.sei
@@ -14,3 +14,14 @@ a + b + c + d + e \\
 x + y + z \\
 + u + v + w
 \end{multiline}
+
+\section{ラベル付きの multiline}
+
+multiline も label 任意引数で環境全体に 1 つラベルを付け、本文から参照できる。
+
+\begin{multiline}[label=eq:multiline-main]
+a + b + c \\
++ d + e
+\end{multiline}
+
+この式は \ref{eq:multiline-main} で参照できる。

--- a/tests/text/split.sei
+++ b/tests/text/split.sei
@@ -14,3 +14,14 @@ a &= b + c + d \\
 u &= v + w \\
 &= x
 \end{split}
+
+\section{ラベル付きの split}
+
+split は label 任意引数で環境全体に 1 つラベルを付け、本文から参照できる。
+
+\begin{split}[label=eq:split-main]
+a &= b + c \\
+&= d
+\end{split}
+
+この式は \ref{eq:split-main} で参照できる。


### PR DESCRIPTION
## 概要

`equation` 以外の採番ありの数式環境（`align` / `gather` / `split` / `multiline`）にラベルを付けて `\ref` で参照できるようにする。Closes #76。

## 変更内容

採番粒度で 2 通りのラベル構文に分ける。

- **`split` / `multiline`（環境単位採番）= 環境の `[label=...]`**
  - `crates/document/src/block.rs`: `DocNode::MathBlock` に `label: Option<String>` を追加。
  - `math_grid::evaluate_math_env`: `SingleEnv` のときスキーマに `[label=...]` を加え、単一採番を `increment` → `increment_with_label` に置換。`MathBlock::label` に載せる。
- **`align` / `gather`（行ごと採番）= 行末マーカー `\label{...}`**
  - `math_grid::evaluate_grid`: `\notag`（#114）と同じ行末マーカー設計に相乗り。引数 `notag_allowed` を `row_markers_allowed` にリネームし、`\label{name}` を検出して `GridRow.label` / `label_span` に格納（必須引数 1 個・行末・1 行に 1 つを検証）。
  - `evaluate_math_env` の `PerRow` 分岐で、採番される各行を `increment_with_label` に通して `MathRow::label` を確定。
- **共通**
  - `crates/lowering/src/lib.rs`: `MathBlock` アームで per-row ラベルに加えブロック単位 `label` も既存 `with_label_anchor` でブロック先頭の `\ref` 到達先アンカーにする。
  - `crates/parser/src/evaluator/error.rs`: `RowLabelNotSupported`（`\label` を equation/split/multiline/cases/matrix で使用）と `RowLabelNotAtRowEnd`（行末以外・引数不正・重複）を `Notag*` と対で追加。
  - 重複ラベルは既存 `increment_with_label` → `DuplicateLabel`、無採番へのラベルは `LabelRequiresNumbering` を流用。

## 設計上の判断

- **`align` / `gather` の行ラベルは行末マーカー `\label{...}`**（issue の「`\notag` 相当の行マーカーに相乗り」案を採用）。効果はその行のみ・位置は行末固定で曖昧さがなく、原則 E1 の例外条件（`\notag` と同じ枠）を満たす。
- **環境単位 `[label=...]` は `SingleEnv`（split/multiline）でのみ受理**。`align` / `gather` の env レベル `[label=...]` は従来どおりスキーマ外（`UnknownOptArgKey`）として弾き、ラベルは行マーカーに一本化する。
- 無採番の行/環境（`\notag` 行・`[numbered=false]`）にラベルは付けられない（参照番号が無いため `LabelRequiresNumbering`）。空ブロック + `[label=...]` は採番もアンカーも出さず、ダングリングアンカーを避ける。

## テスト

- `align` / `gather`: 行ラベルの捕捉と採番継続、`\notag` 行・`[numbered=false]` のラベル拒否、行末以外・重複の拒否。
- `split` / `multiline`: `[label=...]` のブロックラベル捕捉、`[numbered=false]` 併用拒否、`\label` 行マーカー拒否。
- `equation`: `\label` 行マーカー拒否。
- 統合（`crates/parser/tests/evaluate.rs`）: `align` 行ラベル・`split` 環境ラベルを `\ref` で番号解決（`(1.1)`）。
- フィクスチャ `tests/text/{align,gather,split,multiline}.sei` にラベル + `\ref` 例を追加（smoke テストを通過）。
- `cargo +nightly fmt --check` / `cargo clippy --all-targets` / `cargo test`（全パス）。`align` / `split` フィクスチャの PDF ビルドも確認。

## スコープ外

- `cases` / `matrix` は非採番のため参照対象なし（ラベル構文を一切受け付けない）。

## 関連

- Closes #76
- 行マーカー設計を共有: #114（`\notag`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
