### PR TITLE
設定: 数式番号の表示書式と参照書式が別物であることを明文化

### DIFF
--- a/crates/read_style/src/counter.rs
+++ b/crates/read_style/src/counter.rs
@@ -23,6 +23,11 @@
 //! - 例: section の `ref_format = "{display_name} {number}"` → `"Section 1.2"`
 //! - 例: equation の `ref_format = "({number})"` → `"(1.2)"`
 //! - 例: 日本語化したい場合は `display_name = "図"` + `ref_format = "{display_name} {number}"` → `"図 1.2"`
+//!
+//! equation の `ref_format` は `\ref{eq:x}` の表示専用で、式の横に出る番号の体裁を決める
+//! [`crate::EquationStyle::number_format`]（`[equation]`）とは別物。既定値がどちらも `"({number})"`
+//! で一致するのは LaTeX 慣習で「式の横」も「素の相互参照」も括弧付き番号だからで、両者は独立に
+//! 変更できる（`number_format` は `figure` の `caption.format` に相当する数式ブロックの体裁）。
 
 use garde::Validate;
 use serde::{Deserialize, Serialize};

--- a/crates/read_style/src/equation.rs
+++ b/crates/read_style/src/equation.rs
@@ -9,7 +9,11 @@ use types::length::{Length, non_negative};
 #[garde(allow_unvalidated)]
 #[serde(deny_unknown_fields, default)]
 pub struct EquationStyle {
-  /// 数式番号の書式テンプレート。`{number}` を含めることができる
+  /// 式の横に出る数式番号の書式テンプレート。`{number}` を発番番号で置換する（既定 `"({number})"`
+  /// → `"(1.1)"`）。これは「数式ブロックの体裁」（`figure` の `caption.format` に相当）で、
+  /// `\ref{eq:x}` の表示を決める [`crate::CounterStyle::ref_format`]（`counters.equation`）とは別物。
+  /// 既定値が一致するのは LaTeX 慣習で「式の横」も「素の相互参照」も括弧付き番号だからで、両者は
+  /// 独立に変更できる（揃えたいなら両方を直す）。`align` / `gather` / `split` / `multiline` も共有する。
   #[garde(length(chars, min = 1), custom(crate::placeholder::equation_number_format))]
   pub number_format: String,
   /// 数式番号の配置側


### PR DESCRIPTION
## 概要

ディスプレイ数式の番号書式が `equation.number_format`（式の横の表示）と `counters.equation.ref_format`（`\ref` の表示）の 2 箇所にあり、既定値が両方 `"({number})"` で重複して見える問題（#108）について、**方針 (A) 現状維持＋明文化**を採用する。挙動は変えず、2 つが別物であることを doc コメントで明記する。

## 変更内容

- `crates/read_style/src/equation.rs`: `number_format` フィールドの doc を拡充。「式の横に出る番号の体裁」（`figure` の `caption.format` に相当する数式ブロックの体裁）であり、`\ref` の表示を決める `counters.equation.ref_format` とは別物であること、既定値が一致するのは LaTeX 慣習で「式の横」も「素の相互参照」もともに括弧付き番号だからにすぎず両者は独立に変更できること、`align` / `gather` / `split` / `multiline` も共有することを明記。`ref_format` へ intra-doc リンク。
- `crates/read_style/src/counter.rs`: module doc に逆方向の相互参照を追加（equation の `ref_format` は `\ref` 専用で `EquationStyle::number_format` とは別物）。

## 判断の根拠

2 フィールドは役割が本質的に別 — `number_format`=数式ブロックの体裁、`ref_format`=全カウンタ共通の相互参照書式。既定一致は慣習由来にすぎず、独立した自由度（横=`(1.1)`／参照=`式 (1.1)`）に意味がある。(C) 統一は全カウンタの `ref_format` 対称性を壊し自由度を奪うため、(B) 改名/デフォルト変更は eqref 慣習を崩し既存出力を変える割に利得が薄いため不採用。

なお、フィールド名そのものを分かりやすくする改名・配置・数式テーブル再編は、より広い設計見直しとして別エピックに切り出す（本 PR は #108 の明文化に限定）。

## 確認

- `cargo +nightly fmt` / `cargo clippy -p read_style`（警告なし）/ `cargo doc`（新規 intra-doc リンクは警告ゼロ）/ `cargo test -p read_style`（9 passed）/ ワークスペースビルド OK。挙動変更なし。

Closes #108