### PR TITLE
組版: 内容のないページへの改ページを抑止する

### DIFF
--- a/crates/hlist/src/break_pages.rs
+++ b/crates/hlist/src/break_pages.rs
@@ -74,7 +74,17 @@ impl PageComposer {
   ///
   /// 未解決アンカー（`pending_anchors`）は引き継ぐ。次の実ブロックがこの新ページに
   /// 配置されたときに解決されるため、移動はしない。
+  ///
+  /// 現在ページにまだ本文ブロックが 1 つも置かれていない場合は何もしない（ページを
+  /// 送らない）。これにより、先頭が見出しのときの白紙の先頭ページや、内容を挟まない
+  /// 連続改ページ（Part の `page_break_after` の直後に Chapter の `page_break_before`
+  /// が続く等）による中間の白紙ページが生じない。判定は本文ブロック（`current`）の
+  /// 有無のみで行う。走り文はページ数確定後の別パスで載るため判定に含めず、ゼロサイズの
+  /// アンカー・リンクも本文ブロックではないため含めない。
   fn start_new_page(&mut self, geom: &PageGeometry) {
+    if self.current.is_empty() {
+      return;
+    }
     self.pages.push(Page {
       blocks: std::mem::take(&mut self.current),
       header: Vec::new(),
@@ -708,7 +718,7 @@ mod tests {
 
   #[test]
   fn multiple_page_breaks_create_multiple_pages() {
-    // 連続する PageBreak は都度ページを分ける
+    // 内容を挟んだ PageBreak は都度ページを分ける
     let geom = test_geometry();
     let blocks = vec![
       paragraph_of_lines(1),
@@ -721,6 +731,37 @@ mod tests {
     let pages = break_pages(blocks, 100.0, &geom, &GreedyBreaker);
 
     assert_eq!(pages.len(), 3);
+  }
+
+  #[test]
+  fn leading_page_break_does_not_create_blank_page() {
+    // 先頭が改ページ（Part 見出しの page_break_before 相当）でも、白紙の先頭ページを作らない
+    let geom = test_geometry();
+    let blocks = vec![Block::PageBreak, paragraph_of_lines(1)];
+
+    let pages = break_pages(blocks, 100.0, &geom, &GreedyBreaker);
+
+    assert_eq!(pages.len(), 1, "{pages:?}");
+    assert_eq!(pages[0].blocks.len(), 1, "本文は先頭ページに置かれる");
+  }
+
+  #[test]
+  fn consecutive_page_breaks_without_content_collapse() {
+    // 内容を挟まない連続改ページはページ境界 1 つに畳まれる
+    // （Part の page_break_after の直後に Chapter の page_break_before が続く状況に相当）。
+    let geom = test_geometry();
+    let blocks = vec![
+      paragraph_of_lines(1),
+      Block::PageBreak,
+      Block::PageBreak,
+      paragraph_of_lines(1),
+    ];
+
+    let pages = break_pages(blocks, 100.0, &geom, &GreedyBreaker);
+
+    assert_eq!(pages.len(), 2, "中間に白紙ページは生じない: {pages:?}");
+    assert_eq!(pages[0].blocks.len(), 1);
+    assert_eq!(pages[1].blocks.len(), 1);
   }
 
   #[test]


### PR DESCRIPTION
## 概要

見出しに伴う改ページ（既定では Part の前後・Chapter の前）や明示の改ページが、本文のない白紙ページを生むことがあった。縦組版で「現在ページにまだ本文ブロックが置かれていない改ページ」を抑止し、不要な白紙ページをなくす。Closes #68

## 変更内容

- `crates/hlist/src/break_pages.rs` の `PageComposer::start_new_page` に、`self.current`（本文ブロック）が空のとき早期 return するガードを追加した。
- 見出し由来の改ページ・明示の改ページ・タイトルページは、いずれも `Block::PageBreak` → `start_new_page` に集約されるため、この 1 か所のガードで以下がまとめて解消される。
  - 先頭が見出しの文書: 空のままの先頭ページに対する `page_break_before` が no-op になり、白紙の先頭ページが出ない。
  - Part の直後に Chapter: Part の `page_break_after` が開いた空ページに Chapter の `page_break_before` が再度かかっても no-op になり、間の白紙ページが残らない。
  - 内容を挟まない連続改ページ: ページ境界が高々 1 つに畳まれる。
- 現在ページに本文がある状態の改ページは `current` が非空のため従来どおりページを送る（回帰なし）。

## 設計上の判断

- 「内容なし」の判定は本文ブロック（`current`）の有無のみで行う。走り文はページ数確定後の別パス（`build_running_content`）で載るため判定に含めず、ゼロサイズのアンカー・リンクは `current_anchors` / `current_links` / `pending_anchors` という別ベクタにあり本文ブロックではないため含めない。
- ガードを `PageBreak` 専用にせず全 `start_new_page` 呼び出しに効かせた。オーバーフロー由来の改ページ（画像・罫線・行・数式・表）も、対象ページが空のときは現在ページにそのまま置く方が白紙ページを挟まずに済むため、副次的にページより大きい要素の白紙ページ問題も解消する。

## テスト

- 追加: `leading_page_break_does_not_create_blank_page`（先頭改ページで白紙先頭ページを作らない）、`consecutive_page_breaks_without_content_collapse`（内容を挟まない連続改ページがページ境界 1 つに畳まれる）。
- 既存 `multiple_page_breaks_create_multiple_pages`（内容を挟んだ改ページは都度ページを分ける）でコメントを実態に合わせて更新。回帰確認は既存の `page_break_block_starts_new_page` も担う。
- `cargo test`（全クレート）/ `cargo clippy -p hlist` / `cargo +nightly fmt` いずれもパス。

## スコープ外

- ウィドウ／オーファン制御。
- `page_break_before` / `page_break_after` の意味付けそのものの変更。

## 関連

Closes #68