### PR TITLE
組版: 段落先頭の字下げを抑止する \noindent コマンドを実装する

### DIFF
--- a/crates/citation/src/lib.rs
+++ b/crates/citation/src/lib.rs
@@ -250,6 +250,7 @@ fn collect_cite_inlines<'a>(inlines: &'a mut [InlineNode], out: &mut Vec<&'a mut
       | InlineNode::InlineMath(_)
       | InlineNode::Symbol(_)
       | InlineNode::LineBreak
+      | InlineNode::NoIndent
       | InlineNode::Ref { .. } => {},
     }
   }
@@ -739,6 +740,7 @@ mod tests {
         | InlineNode::InlineMath(_)
         | InlineNode::Symbol(_)
         | InlineNode::LineBreak
+        | InlineNode::NoIndent
         | InlineNode::Ref { .. }
         | InlineNode::Cite { .. } => {},
       }

--- a/crates/document/src/inline.rs
+++ b/crates/document/src/inline.rs
@@ -55,6 +55,15 @@ pub enum InlineNode {
   /// 強制改行（`\\`）
   LineBreak,
 
+  /// 段落先頭行の字下げ抑止マーカー（`\noindent`）
+  ///
+  /// 描画されない制御マーカー。パーサ（`evaluate_children`）が段落の先頭にのみ許可して
+  /// 段落のインライン列の先頭に置き、`lowering` 層がこれを見つけたら段落先頭行の字下げ
+  /// （`first_line_indent`）を抑止しつつマーカー自体は出力しない。位置検証はパーサが行うため、
+  /// `lowering` は出現位置を問わず「存在すれば抑止」とみなしてよい。`\\`（[`InlineNode::LineBreak`]）
+  /// と同じく本文の意味を持たないレイアウト制御マーカー。
+  NoIndent,
+
   /// 相互参照（`\ref{label}`）
   ///
   /// `CounterRegistry` での 2 パス評価で解決される。`number` は pass1 では `None`、
@@ -138,6 +147,8 @@ impl InlineNode {
       InlineNode::InlineMath(_) => return "[Math]".to_string(),
       InlineNode::Symbol(ch) => return ch.to_string(),
       InlineNode::LineBreak => return "\n".to_string(),
+      // 非描画マーカーなのでプレーンテキストには何も寄与しない
+      InlineNode::NoIndent => return String::new(),
       InlineNode::Ref { number, .. } => return number.clone().unwrap_or_default(),
       InlineNode::Link { children, .. } | InlineNode::InternalLink { children, .. } => {
         return inline_nodes_to_plain_text(children);

--- a/crates/lowering/src/inline.rs
+++ b/crates/lowering/src/inline.rs
@@ -57,6 +57,11 @@ pub(super) fn lower_inline(
     InlineNode::LineBreak => {
       return Ok(vec![LayoutNode::LineBreak]);
     },
+    InlineNode::NoIndent => {
+      // 非描画の字下げ抑止マーカー。段落字下げの抑止は `lower_paragraph` が担い、
+      // 通常は同関数がマーカーを除去するためここには到達しないが、防御的に空を返す。
+      return Ok(Vec::new());
+    },
     InlineNode::Ref {
       label,
       number,

--- a/crates/lowering/src/paragraph.rs
+++ b/crates/lowering/src/paragraph.rs
@@ -27,15 +27,23 @@ pub(super) fn lower_paragraph(ctx: &LoweringContext, inlines: &[InlineNode]) -> 
 
   let mut result = Vec::new();
 
+  // `\noindent`（[`InlineNode::NoIndent`] マーカー）が段落にあれば字下げを抑止する。位置検証は
+  // パーサ（`evaluate_children`）が段落先頭に限定済みなので、ここでは存在の有無だけを見る。
+  let suppress_indent = inlines.iter().any(|inline| matches!(inline, InlineNode::NoIndent));
+
   // 段落先頭行の字下げ。先頭に水平カーンを置くと、貪欲法ブレーカが先頭行だけ右へずらして
-  // 折り返し幅を狭める（2 行目以降には残らない）。0pt のときは何も足さない（従来挙動）。
-  if ctx.first_line_indent.to_pt() > 0.0 {
+  // 折り返し幅を狭める（2 行目以降には残らない）。0pt のとき・`\noindent` 指定時は何も足さない。
+  if ctx.first_line_indent.to_pt() > 0.0 && !suppress_indent {
     result.push(LayoutNode::Kern {
       length: ctx.first_line_indent,
     });
   }
 
   for inline in inlines {
+    // 非描画マーカーは出力に寄与しないので読み飛ばす
+    if matches!(inline, InlineNode::NoIndent) {
+      continue;
+    }
     result.extend(lower_inline(ctx, inline, default_style)?);
   }
 
@@ -107,6 +115,21 @@ mod tests {
     };
     assert!((length.to_pt() - 15.0).abs() < f32::EPSILON);
     assert!(matches!(&nodes[1], LayoutNode::Text(t, _) if t == "body"));
+  }
+
+  #[test]
+  fn paragraph_noindent_marker_suppresses_indent_kern() {
+    // Arrange — first_line_indent を 15pt にした文脈で、先頭に NoIndent マーカーがある段落
+    let style = ReadStyle::default();
+    let ctx = LoweringContext::new(&style).with_first_line_indent(types::Length::pt(15.0));
+    let inlines = [InlineNode::NoIndent, InlineNode::Text("body".to_string())];
+
+    // Act
+    let nodes = lower_paragraph(&ctx, &inlines).expect("失敗しない");
+
+    // Assert — 字下げ Kern は出ず、マーカーも描画されず、先頭は本文 Text
+    assert!(!nodes.iter().any(|n| matches!(n, LayoutNode::Kern { .. })), "字下げ Kern は抑止される: {nodes:?}");
+    assert!(matches!(&nodes[0], LayoutNode::Text(t, _) if t == "body"), "先頭は本文 Text: {nodes:?}");
   }
 
   #[test]

--- a/crates/parser/src/evaluator.rs
+++ b/crates/parser/src/evaluator.rs
@@ -131,6 +131,16 @@ impl Evaluator {
               CommandResult::Inline(inline_nodes) => {
                 current_inlines.extend(inline_nodes);
               },
+              CommandResult::NoIndent { span } => {
+                // `\noindent` は段落の先頭にのみ置ける。先行する空白・改行（トリビア）は
+                // 許すが、実体のあるインライン要素が既にあれば段落途中なのでエラー。直前に
+                // 置いた `NoIndent` マーカー自体も非空白なので、同一段落への二重 `\noindent`
+                // もここで弾かれる。マーカーは段落のインライン列に積み、`lowering` が字下げを抑止する。
+                if current_inlines.iter().any(is_non_blank_inline) {
+                  return Err(EvalError::NoindentNotAtParagraphStart { span });
+                }
+                current_inlines.push(InlineNode::NoIndent);
+              },
             }
           },
           SyntaxKind::Environment => {
@@ -178,4 +188,16 @@ impl Evaluator {
     doc_nodes.push(DocNode::Paragraph(std::mem::take(current_inlines)));
     return;
   }
+}
+
+/// 段落の先頭判定用に、インライン要素が「実体のある内容」かどうかを返す
+///
+/// 空白のみの `Text`（段落先頭のインデント等）は内容なし（`false`）とみなし、それ以外
+/// （記号・数式・`\noindent` マーカー等）はすべて内容あり（`true`）とする。`\noindent` を
+/// 段落の先頭に限定する際、先行する空白トリビアは許しつつ実体の有無を見分けるために使う。
+fn is_non_blank_inline(inline: &InlineNode) -> bool {
+  return match inline {
+    InlineNode::Text(text) => !text.trim().is_empty(),
+    _ => true,
+  };
 }

--- a/crates/parser/src/evaluator/cite.rs
+++ b/crates/parser/src/evaluator/cite.rs
@@ -105,6 +105,7 @@ fn collect_unknown_in_inlines(inlines: &[InlineNode], keys: &HashSet<String>, la
       | InlineNode::InlineMath(_)
       | InlineNode::Symbol(_)
       | InlineNode::LineBreak
+      | InlineNode::NoIndent
       | InlineNode::Ref { .. } => {},
     }
   }

--- a/crates/parser/src/evaluator/command.rs
+++ b/crates/parser/src/evaluator/command.rs
@@ -23,6 +23,7 @@
 //!    `CommandKind` にバリアントを追加し、`execute()` にハンドラを実装します。
 
 use document::{DocNode, HeadingLevel, InlineNode};
+use miette::SourceSpan;
 use phf::phf_map;
 use syntax::ast::CommandView;
 use types::FontKind;
@@ -46,6 +47,11 @@ pub(crate) enum CommandResult {
   Block(Vec<DocNode>),
   /// インラインレベルのドキュメントノード（記号文字等）
   Inline(Vec<InlineNode>),
+  /// `\noindent` — 段落先頭行の字下げ抑止マーカー
+  ///
+  /// 「段落の先頭にのみ置ける」という位置検証は段落境界を知る `evaluate_children` が行うため、
+  /// ここではマーカーであることとソース位置だけを運ぶ（`span` は位置エラー時の診断に使う）。
+  NoIndent { span: SourceSpan },
 }
 
 /// コマンドの種類
@@ -78,6 +84,8 @@ pub(crate) enum CommandKind {
   Url,
   /// `\href[url=uri]{表示}` — 表示テキストと外部 URI を別に指定する外部リンク
   Href,
+  /// `\noindent` — 段落先頭行の字下げを抑止するマーカー（引数なし）
+  NoIndent,
 }
 
 impl CommandKind {
@@ -99,6 +107,10 @@ impl CommandKind {
       Self::Url => link::url_command(view).map(CommandResult::Inline),
 
       Self::Href => link::href_command(view).map(CommandResult::Inline),
+
+      Self::NoIndent => control::noindent(view).map(|()| CommandResult::NoIndent {
+        span: view.span().into(),
+      }),
     }
   }
 }
@@ -124,6 +136,7 @@ pub(crate) fn single_char(view: &CommandView, ch: char) -> Result<Vec<InlineNode
 pub(crate) static COMMAND_MAP: phf::Map<&'static str, CommandKind> = phf_map! {
   // 制御コマンド
   "space" => CommandKind::Space,
+  "noindent" => CommandKind::NoIndent,
 
   // 相互参照
   "ref" => CommandKind::Ref,

--- a/crates/parser/src/evaluator/command/control.rs
+++ b/crates/parser/src/evaluator/command/control.rs
@@ -58,6 +58,26 @@ pub(super) fn space(view: &CommandView) -> Result<Vec<DocNode>, EvalError> {
   return Ok(vec![DocNode::Space(Length::pt(space_value))]);
 }
 
+/// `\noindent` — 段落先頭行の字下げを抑止するマーカーコマンド
+///
+/// 引数も任意引数も取らない（`\notag` と同じ引数なしマーカー）。「段落の先頭にのみ置ける」
+/// という位置検証は段落境界を知る `evaluate_children` が担うため、ここでは引数の不在だけを
+/// 検証し、結果は呼び出し側（`CommandKind::execute`）が `CommandResult::NoIndent` に詰める。
+///
+/// # Errors
+///
+/// 任意引数や必須引数が指定されている場合にエラーを返します
+pub(super) fn noindent(view: &CommandView) -> Result<(), EvalError> {
+  let _opt_args = collect_command_opt_args(view, &[])?;
+  if !view.args_is_empty() {
+    return Err(EvalError::ExtraCommandArgument {
+      name: view.name().to_string(),
+      span: view.span().into(),
+    });
+  }
+  return Ok(());
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -94,6 +114,51 @@ mod tests {
 
     // Act
     let result = space(&view);
+
+    // Assert
+    assert!(matches!(result, Err(EvalError::UnknownOptArgKey { ref key, .. }) if key == "draft"));
+  }
+
+  #[test]
+  fn noindent_accepts_no_args() {
+    // Arrange — 引数なしの `\noindent` は受理される
+    let arena = Bump::new();
+    let source = r"\noindent";
+    let node = get_command_view(source, &arena);
+    let view = CommandView::new(node, source);
+
+    // Act
+    let result = noindent(&view);
+
+    // Assert
+    assert!(result.is_ok());
+  }
+
+  #[test]
+  fn noindent_rejects_mandatory_argument() {
+    // Arrange — `\noindent{x}` は引数過剰でエラー
+    let arena = Bump::new();
+    let source = r"\noindent{x}";
+    let node = get_command_view(source, &arena);
+    let view = CommandView::new(node, source);
+
+    // Act
+    let result = noindent(&view);
+
+    // Assert
+    assert!(matches!(result, Err(EvalError::ExtraCommandArgument { ref name, .. }) if name == "noindent"));
+  }
+
+  #[test]
+  fn noindent_rejects_unknown_opt_arg_key() {
+    // Arrange — `\noindent` は任意引数を受け付けない
+    let arena = Bump::new();
+    let source = r"\noindent[draft]";
+    let node = get_command_view(source, &arena);
+    let view = CommandView::new(node, source);
+
+    // Act
+    let result = noindent(&view);
 
     // Assert
     assert!(matches!(result, Err(EvalError::UnknownOptArgKey { ref key, .. }) if key == "draft"));

--- a/crates/parser/src/evaluator/counter.rs
+++ b/crates/parser/src/evaluator/counter.rs
@@ -506,6 +506,7 @@ fn resolve_inlines(inlines: &mut [InlineNode], registry: &CounterRegistry) -> Re
       | InlineNode::InlineMath(_)
       | InlineNode::Symbol(_)
       | InlineNode::LineBreak
+      | InlineNode::NoIndent
       | InlineNode::Cite { .. } => {},
     }
   }

--- a/crates/parser/src/evaluator/error.rs
+++ b/crates/parser/src/evaluator/error.rs
@@ -314,6 +314,22 @@ pub enum EvalError {
     span: SourceSpan,
   },
 
+  /// `\noindent`（段落先頭行の字下げ抑止マーカー）が段落の先頭以外に置かれた場合
+  ///
+  /// `\noindent` は「その段落の先頭行を字下げしない」マーカーで、段落の先頭（先行する空白・改行
+  /// トリビアを除く最初の内容）にのみ置ける。段落の途中・引数付き（`\noindent{...}`）・同一段落に
+  /// 複数（2 つ目以降）はエラーにする。
+  #[error("\\noindent は段落の先頭にのみ置けます")]
+  #[diagnostic(
+    code(parser::eval::noindent_not_at_paragraph_start),
+    help("\\noindent は各段落の先頭に 1 つだけ、引数なしで置いてください。")
+  )]
+  NoindentNotAtParagraphStart {
+    /// `\noindent` のソース位置
+    #[label("この \\noindent は段落の先頭にありません")]
+    span: SourceSpan,
+  },
+
   /// 行ラベルマーカー `\label` が行ごと採番でない数式環境に現れた場合
   ///
   /// `\label{...}` は行ごとに採番する `align` / `gather` の行末でのみ意味を持つ。`equation` /

--- a/crates/parser/src/evaluator/inline.rs
+++ b/crates/parser/src/evaluator/inline.rs
@@ -121,7 +121,7 @@ pub(crate) fn extract_inline_nodes_from_elements(
             Some(CommandKind::Href) => {
               inlines.extend(href_command(&view)?);
             },
-            Some(CommandKind::Headline(_) | CommandKind::Space) => {
+            Some(CommandKind::Headline(_) | CommandKind::Space | CommandKind::NoIndent) => {
               return Err(EvalError::BlockInInline {
                 what: format!("\\{}", view.name()),
                 span: view.span().into(),

--- a/crates/parser/tests/evaluate.rs
+++ b/crates/parser/tests/evaluate.rs
@@ -885,6 +885,71 @@ fn evaluate_inline_wrapper_extra_arg_in_heading_is_error() {
 }
 
 #[test]
+fn evaluate_noindent_at_paragraph_start_prepends_marker() {
+  // 段落の先頭の \noindent は段落のインライン列の先頭に NoIndent マーカーを置く
+  let result = evaluate_source(r"\noindent Body");
+  assert_eq!(result.len(), 1);
+  let DocNode::Paragraph(inlines) = &result[0] else {
+    panic!("Paragraph が期待されます: {result:?}");
+  };
+  assert!(matches!(&inlines[0], InlineNode::NoIndent), "先頭は NoIndent マーカー: {inlines:?}");
+  assert!(
+    inlines.iter().any(|n| matches!(n, InlineNode::Text(t) if t == "Body")),
+    "本文 Text は保持される: {inlines:?}"
+  );
+}
+
+#[test]
+fn evaluate_noindent_after_paragraph_break_is_at_start() {
+  // 空行で区切られた 2 段落目の先頭 \noindent も段落先頭として受理される
+  let result = evaluate_source("First.\n\n\\noindent Second.");
+  assert_eq!(result.len(), 2);
+  let DocNode::Paragraph(second) = &result[1] else {
+    panic!("2 段落目は Paragraph: {result:?}");
+  };
+  assert!(matches!(&second[0], InlineNode::NoIndent), "2 段落目の先頭は NoIndent: {second:?}");
+}
+
+#[test]
+fn evaluate_noindent_allows_leading_whitespace() {
+  // 先行する空白トリビアは「段落の先頭」判定で内容とみなさない（受理される）
+  let result = evaluate_source("  \\noindent x");
+  assert_eq!(result.len(), 1);
+  let DocNode::Paragraph(inlines) = &result[0] else {
+    panic!("Paragraph が期待されます: {result:?}");
+  };
+  assert!(inlines.iter().any(|n| matches!(n, InlineNode::NoIndent)), "NoIndent マーカーを含む: {inlines:?}");
+}
+
+#[test]
+fn evaluate_noindent_mid_paragraph_is_error() {
+  // 段落の途中（実体のある内容の後ろ）の \noindent はエラー
+  let error = evaluate_error(r"hello \noindent world");
+  assert!(matches!(error, EvalError::NoindentNotAtParagraphStart { .. }));
+}
+
+#[test]
+fn evaluate_noindent_twice_is_error() {
+  // 同一段落への 2 つ目の \noindent はエラー（直前のマーカーは非空白として残るため）
+  let error = evaluate_error(r"\noindent \noindent x");
+  assert!(matches!(error, EvalError::NoindentNotAtParagraphStart { .. }));
+}
+
+#[test]
+fn evaluate_noindent_with_argument_is_error() {
+  // \noindent は引数を取らない
+  let error = evaluate_error(r"\noindent{x}");
+  assert!(matches!(error, EvalError::ExtraCommandArgument { ref name, .. } if name == "noindent"));
+}
+
+#[test]
+fn evaluate_noindent_in_heading_is_error() {
+  // インライン文脈（見出しタイトル）での \noindent はブロック扱いでエラー
+  let error = evaluate_error(r"\section{\noindent x}");
+  assert!(matches!(error, EvalError::BlockInInline { .. }));
+}
+
+#[test]
 fn evaluate_paragraph_break_in_argument_is_error() {
   // 引数内の空行は以前黙って捨てられ前後が連結されていた
   let error = evaluate_error("\\section{a\n\nb}");


### PR DESCRIPTION
## 概要

first-line indent（#120）が有効なスタイル（`[text].first_line_indent > 0`）のとき、特定の段落だけ先頭行の字下げを抑止するマーカーコマンド `\noindent` を追加する。LaTeX の `\noindent` 相当。

Closes #129

## 変更内容

- **document**: `InlineNode` に非描画マーカー `NoIndent` を追加（`\\` = `LineBreak` と同じレイアウト制御マーカーの位置づけ）。`DocNode::Paragraph(Vec<InlineNode>)` のシグネチャは変えずに段落へ字下げ抑止情報を運ぶ設計とし、変種変更による広域改変を避けた。`to_plain_text` は空文字列を返す。
- **parser**:
  - `COMMAND_MAP` に `"noindent" => CommandKind::NoIndent` を登録。`command::control::noindent` が引数・任意引数の不在を検証し、`execute` が `CommandResult::NoIndent { span }` を返す（`span` は位置エラー診断用）。
  - 位置検証は段落境界を知る `evaluator::evaluate_children` に置いた。`\noindent` は段落の先頭（先行する空白・改行トリビアを除く最初の内容）にのみ許可し、`InlineNode::NoIndent` マーカーを段落のインライン列へ積む。実体のある内容の後ろ・同一段落への 2 つ目はソース位置付きの `EvalError::NoindentNotAtParagraphStart` にする（直前のマーカーは非空白とみなすため二重指定も同じ経路で弾かれる）。判定には新ヘルパ `is_non_blank_inline` を使う。
  - インライン文脈（見出しタイトル・キャプション・`\bold{...}` 引数等）の `\noindent` は `extract_inline_nodes` のブロック扱いに加え、`EvalError::BlockInInline` で弾く。
  - pass2 系の `InlineNode` 走査（`counter::resolve_inlines` / `cite::collect_unknown_in_inlines`）と `citation` の引用収集は、`NoIndent` を子を持たないリーフとして no-op アームに追加。
- **lowering**: `lower_paragraph` がマーカーの有無を見て、`first_line_indent > 0` でもマーカーがあれば先頭の字下げ `Kern` を出さない。描画時はマーカーを読み飛ばす。`lower_inline` には防御的な空アームを追加。

## 設計上の判断

- **宣言型マーカーだが原則 E1 の例外として許容**: `\noindent` の効果は「その段落の先頭行のみ」に構造的に閉じ、置ける位置も段落先頭に一意。`\bfseries` のような「以降ずっと効く」曖昧さがなく、行末固定マーカー `\notag` と同型。引数なしマーカーなので原則 A（引数は `{}` 明示）にも抵触しない。
- **段落 IR のシグネチャを変えずマーカーで表す**: `DocNode::Paragraph` は約 90 箇所で構築・マッチされるため、変種を struct 化せず `InlineNode` の非描画マーカー（`LineBreak` の前例に倣う）で段落属性を運ぶ局所的設計にした。
- **位置検証はパーサ、抑止判定は lowering**: 「段落先頭のみ」はパーサが強制するため、lowering はマーカーの出現位置を問わず「存在すれば抑止」とみなす。
- **字下げ無効スタイルでは no-op**: `first_line_indent == 0pt`（既定のブロック段落方式）では字下げ自体が無いので `\noindent` は出力を変えない（エラーにしない）。字下げありスタイルへ style.toml を差し替えても本文を書き換えず使える。

## テスト

- lowering: マーカーがあると字下げ `Kern` が抑止され、マーカー自体は描画されないことを検証。
- parser（control ユニット）: 引数なし受理 / 必須引数・未知任意引数キーの拒否。
- parser（統合）: 段落先頭での受理（マーカー前置）・空行区切り 2 段落目の先頭・先行空白の許容・段落途中エラー・二重指定エラー・引数付きエラー・見出し内（インライン文脈）エラー。
- E2E: `first_line_indent = "15pt"` のスタイルで 3 段落（中央のみ `\noindent`）を組版し、PDF の語の x 座標で中央段落だけ 15pt 左（字下げなし）になることを確認。
- `cargo test`（全件パス）/ `cargo clippy`（クリーン）/ `cargo +nightly fmt` パス。

## スコープ外

- 「見出し直後の最初の段落は字下げしない」自動抑止（indentfirst 相当）。#120 が将来の精緻化として言及。
- 逆コマンド `\indent`（ブロック段落方式で特定段落だけ強制字下げ）。

## 関連

- Closes #129
- #120（段落先頭の字下げ first-line indent 実装。本コマンドの前提）
