### PR TITLE
ロギング: 既定出力をコンパイラ型に再設計する

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -15,11 +15,11 @@ use clap::{Parser, Subcommand};
 #[command(version = env!("CARGO_PKG_VERSION"))]
 #[command(about = "PDFテキスト生成ツール", long_about = None)]
 pub struct Cli {
-  /// ログの冗長度を上げる（`-v` = DEBUG、`-vv` = TRACE）。`RUST_LOG` 未設定時のみ有効
+  /// ログの冗長度を上げる（`-v` = INFO 進捗、`-vv` = DEBUG、`-vvv` = TRACE）。`RUST_LOG` 未設定時のみ有効
   #[arg(short, long, global = true, action = clap::ArgAction::Count, conflicts_with = "quiet")]
   pub verbose: u8,
 
-  /// ログの冗長度を下げる（WARN 以上のみ表示）。`RUST_LOG` 未設定時のみ有効
+  /// 警告も抑止しエラーのみ表示する（成功時は無言）。`RUST_LOG` 未設定時のみ有効
   #[arg(short, long, global = true)]
   pub quiet: bool,
 

--- a/crates/seiran/src/build_pdf.rs
+++ b/crates/seiran/src/build_pdf.rs
@@ -2,7 +2,12 @@
 //! このモジュールは、設定ファイルの `sources` に列挙されたテキストファイルから
 //! PDF を生成するための主要な機能を提供します。
 
-use std::{collections::HashSet, fs, path::Path, time::Instant};
+use std::{
+  collections::HashSet,
+  fs,
+  path::{Path, PathBuf},
+  time::Instant,
+};
 
 use citation::CitationError;
 use document::DocNode;
@@ -16,6 +21,19 @@ use miette::Diagnostic;
 use parser::ParseSourceError;
 use thiserror::Error;
 use tracing::{debug, debug_span, info};
+
+/// ビルド成功時のサマリ（ユーザーチャンネルのレポータが表示する最小情報）
+///
+/// `tracing` の段ログとは別物で、コンパイラ型 CLI の「成果報告 1 行」（出力先・ページ数・所要
+/// 時間）だけを運ぶ。表示は呼び出し側（`main::report_build`）が担う。
+pub(super) struct BuildSummary {
+  /// 出力した PDF のパス
+  pub(super) output_path: PathBuf,
+  /// 総ページ数
+  pub(super) page_count: usize,
+  /// ビルド全体の所要ミリ秒
+  pub(super) total_elapsed_ms: u64,
+}
 
 /// PDF ビルド時のエラー型
 #[derive(Debug, Error, Diagnostic)]
@@ -98,7 +116,12 @@ enum BuildPdfError {
 /// # Arguments
 ///
 /// * `config_path` - 設定ファイルのパス
-pub(super) fn build_pdf(config_path: &Path) -> miette::Result<()> {
+///
+/// # Returns
+///
+/// 成功時は [`BuildSummary`]（出力先・ページ数・所要時間）。ユーザー向けの成果報告は呼び出し側の
+/// `report_build` が担うため、ここでは最終サマリを `tracing` には出さない（二重表示を避ける）。
+pub(super) fn build_pdf(config_path: &Path) -> miette::Result<BuildSummary> {
   let build_start = Instant::now();
   info!(config_path = %config_path.display(), "PDF のビルドを開始します");
 
@@ -279,8 +302,11 @@ pub(super) fn build_pdf(config_path: &Path) -> miette::Result<()> {
   })?;
   info!(output_path = %output_path.display(), elapsed_ms = elapsed_ms(stage_start), "PDF の保存が完了しました");
 
-  info!(page_count = pages.len(), total_elapsed_ms = elapsed_ms(build_start), "ビルドが完了しました");
-  return Ok(());
+  return Ok(BuildSummary {
+    output_path,
+    page_count: pages.len(),
+    total_elapsed_ms: elapsed_ms(build_start),
+  });
 }
 
 /// ステージ開始時刻からの経過ミリ秒を返す（INFO サマリの `elapsed_ms` 用）。

--- a/crates/seiran/src/main.rs
+++ b/crates/seiran/src/main.rs
@@ -27,23 +27,27 @@
 //! - `ttc-names <ttc_file>` - TTC ファイル内のフォント名一覧を表示
 //! - `script-langs <font>` - フォント対応の Script/Language タグを表示
 //!
-//! ## ロギング
+//! ## ロギングと出力（コンパイラ型）
 //!
-//! 既定では INFO レベル以上のトレーシングログを、RFC 3339 タイムスタンプ付きで標準エラー出力に
-//! 記録します。観測・進捗の表示は `tracing` が担い、ユーザ向けの致命的エラーは `miette` 診断が
-//! 担当します（役割を二重化しない）。
+//! `gcc` / `cargo` / `typst` のようなコンパイラ型 CLI に倣い、**成功時は静か**にする。出力は 2 つの
+//! 独立したチャンネルに分ける:
+//!
+//! - **ユーザーチャンネル（非 tracing のレポータ）**: ビルド成功時に **サマリ 1 行**（出力先・
+//!   ページ数・所要時間）を stderr に出すだけ（[`report_build`]）。`tracing` のレベルとは独立で、
+//!   `-q`（quiet）でのみ抑止する。
+//! - **診断チャンネル（`tracing`）**: 既定は **WARN 以上のみ**。段ごとの進捗（INFO）は `-v` で
+//!   オプトインする。致命的エラーは `miette` 診断が担当し、`tracing` の ERROR と二重化しない。
 //!
 //! ### レベル方針（taxonomy）
 //!
-//! - **ERROR**: 原則使わない。ユーザ向けの致命的エラーは `miette` 診断が担当し、`tracing` の
-//!   ERROR と二重化しない。
-//! - **WARN**: 処理は続行するが利用者が知るべき事象（フォントフォールバック、ソース拡張子の
-//!   不一致、GSUB / GPOS テーブル欠如など）。
-//! - **INFO**: 既定表示。build パイプラインの各ステージ完了とサマリ指標（件数・ページ数・所要
+//! - **ERROR**: 原則使わない。ユーザ向けの致命的エラーは `miette` 診断が担当する。
+//! - **WARN**: **既定表示**。処理は続行するが利用者が知るべき事象（フォントフォールバック、
+//!   ソース拡張子の不一致、GSUB / GPOS テーブル欠如など）。黙って品質を落とさないための最後の砦。
+//! - **INFO**: `-v` で表示。build パイプラインの各ステージ完了とサマリ指標（件数・ページ数・所要
 //!   時間 `elapsed_ms`）のみ。「実行を追える粒度」に限定する。
-//! - **DEBUG**: 段の内部詳細（ソースごと・ブロックごと・ページごと・フォントごと等のループ
-//!   単位）。各コア処理クレートが自段の完了を DEBUG で出す。
-//! - **TRACE**: 最細粒度（トークン・グリフ単位）。現状は未使用（枠のみ定義）。
+//! - **DEBUG**: `-vv` で表示。段の内部詳細（ソースごと・ブロックごと・ページごと・フォントごと
+//!   等のループ単位）。各コア処理クレートが自段の完了を DEBUG で出す。
+//! - **TRACE**: `-vvv` で表示。最細粒度（トークン・グリフ単位）。現状は未使用（枠のみ定義）。
 //!
 //! ### 構造化フィールドの命名規約
 //!
@@ -54,23 +58,32 @@
 //!   DEBUG 完了ログを区別できるよう、呼び出し側で `debug_span!` を張りフィールドで文脈を付ける
 //!   （`region`＝本文 / タイトル等の区間、`pass`＝ページ分割の Pass 番号）。
 //!
+//! ### 表示形式
+//!
+//! 診断チャンネルは `compact` フォーマッタで 1 イベント 1 行。壁時計タイムスタンプ・ソース行番号・
+//! target は出さない（時間は `elapsed_ms` フィールドが担うため毎行の時刻は不要）。
+//!
 //! ### 冗長度の制御
 //!
-//! 何も指定しなければ既定どおり INFO 以上のみを表示する。冗長度の切り替えは 2 系統:
+//! 既定（フラグなし）は WARN + サマリ 1 行。冗長度の切り替えは 2 系統:
 //!
-//! - **第一級（一般ユーザ向け、CLI フラグ）**: グローバルフラグ `-v` / `-q` で冗長度を上下する。
-//!   全サブコマンドに効き `--help` に出る。`-v` = DEBUG、`-vv` = TRACE（繰り返しで段階を上げる）。
-//!   `-q` / `--quiet` = WARN 以上のみ（INFO 進捗を抑制）。`-v` と `-q` は相互排他。
+//! - **第一級（一般ユーザ向け、CLI フラグ）**: グローバルフラグ `-v` / `-q` で上下する。全サブ
+//!   コマンドに効き `--help` に出る。`-v` = INFO（ステージ進捗）、`-vv` = DEBUG、`-vvv` = TRACE
+//!   （繰り返しで段階を上げる）。`-q` / `--quiet` = ERROR 以上のみ＋サマリ行も抑止（成功時は
+//!   完全に無言）。`-v` と `-q` は相互排他。
 //! - **補足（開発者向け、環境変数）**: `RUST_LOG`（`tracing-subscriber` の `EnvFilter`）で
 //!   クレート / ターゲット単位に絞り込む（例: `RUST_LOG=seiran=info,layout=debug`）。フラグでは
-//!   表現できない「特定クレートだけ詳しく」を担うエスケープハッチ。
+//!   表現できない「特定クレートだけ詳しく」を担うエスケープハッチ。診断チャンネルのみを制御し、
+//!   ユーザーチャンネルのサマリ行には影響しない。
 //!
-//! **優先順位**: `RUST_LOG`（明示指定時）> `-v` / `-q` フラグ > 既定 INFO。`RUST_LOG` を設定した
-//! ときはそれが全権を持つため、同時に渡した `-v` / `-q` は無視される（`-vv` が効かない場合は
-//! `RUST_LOG` 設定済みを疑う）。`RUST_LOG` のパースに失敗したときは INFO にフォールバックし、
-//! 警告を 1 行出す（黙って無効化しない）。
+//! **優先順位**: `RUST_LOG`（明示指定時）> `-v` / `-q` フラグ > 既定 WARN。`RUST_LOG` を設定した
+//! ときはそれが診断チャンネルの全権を持つため、同時に渡した `-v` / `-q` は無視される（`-vv` が
+//! 効かない場合は `RUST_LOG` 設定済みを疑う）。`RUST_LOG` のパースに失敗したときはフラグ/既定の
+//! 設定にフォールバックし、警告を 1 行出す（黙って無効化しない）。
 
 mod build_pdf;
+use std::io::IsTerminal;
+
 use tracing_subscriber::{EnvFilter, fmt};
 
 /// アプリケーションのメインエントリーポイント
@@ -87,7 +100,10 @@ fn main() -> miette::Result<()> {
   init_logging(cli_args.verbose, cli_args.quiet);
 
   match cli_args.command {
-    cli::Command::Build { config_path } => build_pdf::build_pdf(&config_path)?,
+    cli::Command::Build { config_path } => {
+      let summary = build_pdf::build_pdf(&config_path)?;
+      report_build(&summary, cli_args.quiet);
+    },
     cli::Command::VariationAxes {
       font_path,
       font_index,
@@ -108,20 +124,43 @@ fn main() -> miette::Result<()> {
   return Ok(());
 }
 
-/// 優先順位（`RUST_LOG` > `-v` / `-q` > 既定 INFO）に従ってフィルタを構築し、ロギングを初期化する。
+/// ビルド成功時のサマリを 1 行で stderr に表示する（ユーザーチャンネル＝コンパイラ型の成果報告）。
 ///
-/// `RUST_LOG` のパースに失敗した場合は INFO へフォールバックし、subscriber 初期化後に
-/// 警告を 1 行出す（フィルタ未確定では `tracing::warn!` を出せないため後出しにする）。
+/// `tracing` のレベルとは独立した出力で、`-q`（quiet）指定時のみ抑止する（成功時を完全に無言に
+/// する）。stderr が端末のときだけ ✓ を緑で装飾し、パイプ時は装飾なしのプレーン文字列にする。
+fn report_build(summary: &build_pdf::BuildSummary, quiet: bool) {
+  if quiet {
+    return;
+  }
+  let mark = if std::io::stderr().is_terminal() {
+    "\u{1b}[32m\u{2713}\u{1b}[0m"
+  } else {
+    "\u{2713}"
+  };
+  eprintln!(
+    "{mark} {} · {} ページ · {} ms",
+    summary.output_path.display(),
+    summary.page_count,
+    summary.total_elapsed_ms
+  );
+}
+
+/// 優先順位（`RUST_LOG` > `-v` / `-q` > 既定 WARN）に従ってフィルタを構築し、診断チャンネルを
+/// 初期化する。
+///
+/// フォーマッタは `compact`（1 イベント 1 行）。壁時計タイムスタンプ・ソース行番号・target は出さ
+/// ない（時間は `elapsed_ms` フィールドが担う）。`RUST_LOG` のパースに失敗した場合はフラグ/既定の
+/// 設定へフォールバックし、subscriber 初期化後に警告を 1 行出す（フィルタ未確定では `tracing::warn!`
+/// を出せないため後出しにする）。
 fn init_logging(verbose: u8, quiet: bool) {
   let (filter, warn_msg) = build_env_filter(verbose, quiet);
   fmt::fmt()
-    .pretty()
+    .compact()
     .with_env_filter(filter)
-    .with_thread_ids(false)
-    .with_thread_names(false)
     .with_target(false)
     .with_file(false)
-    .with_timer(fmt::time::LocalTime::rfc_3339())
+    .with_line_number(false)
+    .without_time()
     .init();
   if let Some(msg) = warn_msg {
     tracing::warn!("{msg}");
@@ -140,25 +179,26 @@ fn build_env_filter(verbose: u8, quiet: bool) -> (EnvFilter, Option<String>) {
     match EnvFilter::builder().parse(&raw) {
       Ok(filter) => return (filter, None),
       Err(error) => {
-        let msg = format!("環境変数 RUST_LOG のパースに失敗したため INFO にフォールバックします: {error}");
-        return (EnvFilter::new("info"), Some(msg));
+        let msg = format!("環境変数 RUST_LOG のパースに失敗したため、フラグ/既定の設定にフォールバックします: {error}");
+        return (flag_filter(verbose, quiet), Some(msg));
       },
     }
   }
   return (flag_filter(verbose, quiet), None);
 }
 
-/// `-v` / `-q` フラグからグローバルレベルの `EnvFilter` を作る（既定 INFO）。
+/// `-v` / `-q` フラグからグローバルレベルの `EnvFilter` を作る（既定 WARN）。
 ///
-/// `-q` が WARN 以上、`-v` が DEBUG、`-vv` 以上が TRACE。`-v` と `-q` は CLI 側（clap の
-/// `conflicts_with`）で相互排他なので、両立するケースは到達しない。
+/// `-q` が ERROR 以上、`-v` が INFO、`-vv` が DEBUG、`-vvv` 以上が TRACE。`-v` と `-q` は CLI 側
+/// （clap の `conflicts_with`）で相互排他なので、両立するケースは到達しない。
 fn flag_filter(verbose: u8, quiet: bool) -> EnvFilter {
   let level = if quiet {
-    "warn"
+    "error"
   } else {
     match verbose {
-      0 => "info",
-      1 => "debug",
+      0 => "warn",
+      1 => "info",
+      2 => "debug",
       _ => "trace",
     }
   };


### PR DESCRIPTION
## 概要

`seiran build` の既定出力を「コンパイラ型」に再設計する。成功時は警告と成果サマリ 1 行だけを出し、詳細なステージ進捗は `-v` でオプトインする。Closes #131

## 変更内容

ユーザー向けの成果報告（ユーザーチャンネル）と tracing 診断（診断チャンネル）を分離した。

- **`crates/seiran/src/main.rs`**
  - 成果サマリを出す `report_build`（tracing 非依存・stderr・`-q` で抑止・stderr が端末のときだけ `✓` を緑装飾、`IsTerminal` で判定）を追加。
  - `init_logging` のフォーマッタを `.pretty()` → `.compact()` に変更し、`without_time()` / `with_line_number(false)` / `with_target(false)` / `with_file(false)` で壁時計タイムスタンプ・ソース行番号・target を抑止。
  - `flag_filter` の既定レベルを INFO → **WARN** に下げ、`-v`=INFO / `-vv`=DEBUG / `-vvv`=TRACE、`-q`=ERROR に remap。
  - `build_env_filter` の `RUST_LOG` パース失敗時フォールバックを、ハードコードの INFO からフラグ/既定（`flag_filter`）に変更。
  - モジュールのロギング設計ドキュメント（taxonomy・優先順位・表示形式）を全面改訂。
- **`crates/seiran/src/build_pdf.rs`**
  - `build_pdf` の返り値を `()` → `BuildSummary`（出力先・ページ数・所要時間）に変更し、呼び出し側がサマリを表示できるようにした。
  - 重複する最終ログ `info!("ビルドが完了しました")` を削除（サマリ行と二重になるため）。各ステージの `info!` は据え置き（既定では非表示・`-v` で表示）。
- **`crates/cli/src/lib.rs`**
  - `-v` / `-q` のヘルプ文を新方針（`-v`=INFO 進捗 / `-vv`=DEBUG / `-vvv`=TRACE、`-q`=エラーのみ・成功時無言）に更新。

### 出力例（既定）

```
 WARN スクリプトがテーブルでサポートされていません script_tag=math table_name="GPOS"
✓ /Users/.../target/test_document.pdf · 1 ページ · 102 ms
```

## 設計上の判断

- サマリ行は「データ」ではなく「ステータス」なので stdout ではなく **stderr** に出す（`build` は PDF をファイルに書くため stdout は空に保つ）。
- サマリ文面はコードベースの日本語ボイスに合わせ `N ページ` 表記にした。
- `RUST_LOG` は診断チャンネルのみを制御し、サマリ行（ユーザーチャンネル）には影響させない。

## テスト

- 手動確認: 既定 / `-v` / `-vv` / `-q` / `RUST_LOG` 上書き / 不正 `RUST_LOG` フォールバック をすべて実行し期待どおりの出力を確認。
- `cargo +nightly fmt` / `cargo clippy`（クリーン）/ `cargo test -p seiran`（5 passed）すべて green。

## スコープ外

- 各ステージログの文面・フィールドの増減（taxonomy は #104 を踏襲）。
- サブコマンドのデータ出力、プログレスバー／スピナー等のライブ進捗。

## 関連

- #104 — 冗長度制御（`RUST_LOG` / `-v` / `-q`）の導入。本 PR はその出力 UX をコンパイラ型へ再設計する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
