### PR TITLE
リファクタ: build_pdf をビルド段ごとの補助関数に分割する

### DIFF
--- a/crates/seiran/src/build_pdf.rs
+++ b/crates/seiran/src/build_pdf.rs
@@ -317,6 +317,38 @@ pub(super) fn build_pdf(config_path: &Path) -> miette::Result<BuildSummary> {
 /// ステージ開始時刻からの経過ミリ秒を返す（INFO サマリの `elapsed_ms` 用）。
 fn elapsed_ms(start: Instant) -> u64 { return start.elapsed().as_millis() as u64; }
 
+/// 全 source を順次読み込み、パース結果を結合した `Vec<DocNode>` を返す。
+///
+/// I/O 失敗は早期にエラーを返し、パース・評価エラーは全 source で集約して
+/// [`BuildPdfError::MultipleSourceErrors`] にまとめて返す。
+fn parse_all_sources(
+  sources: &[std::path::PathBuf],
+  style: &read_style::Style,
+  citation_keys: &HashSet<String>,
+) -> Result<Vec<DocNode>, BuildPdfError> {
+  let mut all_nodes: Vec<DocNode> = Vec::new();
+  let mut parse_errors: Vec<ParseSourceError> = Vec::new();
+
+  for source_path in sources {
+    let content = std::fs::read_to_string(source_path).map_err(|source| BuildPdfError::ReadTextFile {
+      path: source_path.display().to_string(),
+      source,
+    })?;
+    let display_path = source_path.display().to_string();
+    match parser::parse_source(&content, &display_path, style, citation_keys) {
+      Ok(nodes) => all_nodes.extend(nodes),
+      Err(error) => parse_errors.push(error),
+    }
+  }
+
+  if !parse_errors.is_empty() {
+    return Err(BuildPdfError::MultipleSourceErrors {
+      errors: parse_errors,
+    });
+  }
+  return Ok(all_nodes);
+}
+
 /// 本文（N 段）と前付け（常に 1 段）の [`hlist::PageGeometry`] を組み立てる。
 ///
 /// 両者は段数・段間以外を共有するため、本文側を組んでから前付けは `num_columns` / `column_gap` だけ
@@ -346,33 +378,20 @@ fn build_page_geometries(
   return (body_geometry, front_geometry);
 }
 
-/// Document IR の見出しから PDF しおり用の [`pdf_gen::OutlineEntry`] を文書順に組み立てる。
+/// 本文 Pass のページ列から、各見出しの本文内ページ index を文書順に採取する。
 ///
-/// テキストは `"{number} {plain title}"`（番号が空なら表題のみ）。見出しの収集は意味側の
-/// 単一ソース [`document::collect_headings`] に委譲する（目次生成と同じソースを使う）。
-fn collect_outline_entries(doc_nodes: &[DocNode]) -> Vec<pdf_gen::OutlineEntry> {
-  return document::collect_headings(doc_nodes)
-    .into_iter()
-    .map(|info| {
-      let plain = document::inline_nodes_to_plain_text(info.title);
-      let text = heading_label(info.number, &plain);
-      return pdf_gen::OutlineEntry {
-        level: info.level,
-        text,
-      };
-    })
-    .collect();
-}
-
-/// 「番号 タイトル」の表示文字列を組む（番号・タイトルの空を考慮）。しおり・目次で共用する。
-fn heading_label(number: &str, title_plain: &str) -> String {
-  if number.is_empty() {
-    return title_plain.to_string();
+/// `pdf_gen::build_destination_index` と同型のアンカー走査。`document::collect_headings` が返す
+/// 見出し列と 1 対 1 に対応する（どちらも文書順）。
+fn heading_page_indices(pages: &[hlist::Page]) -> Vec<usize> {
+  let mut indices = Vec::new();
+  for (page_index, page) in pages.iter().enumerate() {
+    for anchor in &page.anchors {
+      if matches!(anchor.mark, types::AnchorMark::Heading { .. }) {
+        indices.push(page_index);
+      }
+    }
   }
-  if title_plain.is_empty() {
-    return number.to_string();
-  }
-  return format!("{number} {title_plain}");
+  return indices;
 }
 
 /// 前付けブロック（タイトルページ → 目次）を文書順に組み立てて返す。
@@ -412,43 +431,6 @@ fn assemble_front_matter(
     }
   }
   return front_blocks;
-}
-
-/// 前付け（タイトルページ → 目次）ブロックを単独でページ分割する。
-///
-/// 前付けは常に単段（`front_geometry`）。本文ページ列と連結する前提なので、本文との区切り用に末尾へ
-/// 付いている `Block::PageBreak` は落とす（[`hlist::break_pages`] の `finish` が末尾ページを無条件に
-/// push するため、残すと空の末尾ページが生じる）。タイトル → 目次間の中間 `PageBreak` は保持する。
-/// 前付けが空（タイトルページ・目次ともに無効）のときは空ページを作らず空の列を返す。
-fn break_front_matter(
-  mut front_blocks: Vec<hlist::Block>,
-  text_width: f32,
-  front_geometry: &hlist::PageGeometry,
-  breaker: &dyn hlist::LineBreaker,
-) -> Vec<hlist::Page> {
-  if matches!(front_blocks.last(), Some(hlist::Block::PageBreak)) {
-    front_blocks.pop();
-  }
-  if front_blocks.is_empty() {
-    return Vec::new();
-  }
-  return hlist::break_pages(front_blocks, text_width, front_geometry, breaker);
-}
-
-/// 本文 Pass のページ列から、各見出しの本文内ページ index を文書順に採取する。
-///
-/// `pdf_gen::build_destination_index` と同型のアンカー走査。`document::collect_headings` が返す
-/// 見出し列と 1 対 1 に対応する（どちらも文書順）。
-fn heading_page_indices(pages: &[hlist::Page]) -> Vec<usize> {
-  let mut indices = Vec::new();
-  for (page_index, page) in pages.iter().enumerate() {
-    for anchor in &page.anchors {
-      if matches!(anchor.mark, types::AnchorMark::Heading { .. }) {
-        indices.push(page_index);
-      }
-    }
-  }
-  return indices;
 }
 
 /// 見出しと本文内ページ index から目次エントリ列を組み立てる。
@@ -506,6 +488,27 @@ fn build_toc_spec(style: &read_style::Style, text_width: f32) -> layout::TocSpec
   };
 }
 
+/// 前付け（タイトルページ → 目次）ブロックを単独でページ分割する。
+///
+/// 前付けは常に単段（`front_geometry`）。本文ページ列と連結する前提なので、本文との区切り用に末尾へ
+/// 付いている `Block::PageBreak` は落とす（[`hlist::break_pages`] の `finish` が末尾ページを無条件に
+/// push するため、残すと空の末尾ページが生じる）。タイトル → 目次間の中間 `PageBreak` は保持する。
+/// 前付けが空（タイトルページ・目次ともに無効）のときは空ページを作らず空の列を返す。
+fn break_front_matter(
+  mut front_blocks: Vec<hlist::Block>,
+  text_width: f32,
+  front_geometry: &hlist::PageGeometry,
+  breaker: &dyn hlist::LineBreaker,
+) -> Vec<hlist::Page> {
+  if matches!(front_blocks.last(), Some(hlist::Block::PageBreak)) {
+    front_blocks.pop();
+  }
+  if front_blocks.is_empty() {
+    return Vec::new();
+  }
+  return hlist::break_pages(front_blocks, text_width, front_geometry, breaker);
+}
+
 /// 各物理ページの `(\{page\}, \{pages\})` ラベルをリージョン別に算出する。
 ///
 /// 前付け（index `< front_count`）は `page_numbering.front_matter`（既定ローマ数字）で 1 から、
@@ -531,38 +534,6 @@ fn page_number_labels(
     }
   }
   return labels;
-}
-
-/// 全 source を順次読み込み、パース結果を結合した `Vec<DocNode>` を返す。
-///
-/// I/O 失敗は早期にエラーを返し、パース・評価エラーは全 source で集約して
-/// [`BuildPdfError::MultipleSourceErrors`] にまとめて返す。
-fn parse_all_sources(
-  sources: &[std::path::PathBuf],
-  style: &read_style::Style,
-  citation_keys: &HashSet<String>,
-) -> Result<Vec<DocNode>, BuildPdfError> {
-  let mut all_nodes: Vec<DocNode> = Vec::new();
-  let mut parse_errors: Vec<ParseSourceError> = Vec::new();
-
-  for source_path in sources {
-    let content = std::fs::read_to_string(source_path).map_err(|source| BuildPdfError::ReadTextFile {
-      path: source_path.display().to_string(),
-      source,
-    })?;
-    let display_path = source_path.display().to_string();
-    match parser::parse_source(&content, &display_path, style, citation_keys) {
-      Ok(nodes) => all_nodes.extend(nodes),
-      Err(error) => parse_errors.push(error),
-    }
-  }
-
-  if !parse_errors.is_empty() {
-    return Err(BuildPdfError::MultipleSourceErrors {
-      errors: parse_errors,
-    });
-  }
-  return Ok(all_nodes);
 }
 
 /// ページ数確定後のヘッダー・フッター配置仕様 [`layout::RunningContentSpec`] を組み立てる。
@@ -616,6 +587,35 @@ fn running_slots(
     rule_gap: style.rule_gap.to_pt(),
     rule_color: style.rule_color.map(types::Color::rgb),
   });
+}
+
+/// Document IR の見出しから PDF しおり用の [`pdf_gen::OutlineEntry`] を文書順に組み立てる。
+///
+/// テキストは `"{number} {plain title}"`（番号が空なら表題のみ）。見出しの収集は意味側の
+/// 単一ソース [`document::collect_headings`] に委譲する（目次生成と同じソースを使う）。
+fn collect_outline_entries(doc_nodes: &[DocNode]) -> Vec<pdf_gen::OutlineEntry> {
+  return document::collect_headings(doc_nodes)
+    .into_iter()
+    .map(|info| {
+      let plain = document::inline_nodes_to_plain_text(info.title);
+      let text = heading_label(info.number, &plain);
+      return pdf_gen::OutlineEntry {
+        level: info.level,
+        text,
+      };
+    })
+    .collect();
+}
+
+/// 「番号 タイトル」の表示文字列を組む（番号・タイトルの空を考慮）。しおり・目次で共用する。
+fn heading_label(number: &str, title_plain: &str) -> String {
+  if number.is_empty() {
+    return title_plain.to_string();
+  }
+  if title_plain.is_empty() {
+    return number.to_string();
+  }
+  return format!("{number} {title_plain}");
 }
 
 #[cfg(test)]

--- a/crates/seiran/src/build_pdf.rs
+++ b/crates/seiran/src/build_pdf.rs
@@ -232,20 +232,8 @@ pub(super) fn build_pdf(config_path: &Path) -> miette::Result<BuildSummary> {
   info!(elapsed_ms = elapsed_ms(stage_start), "画像サイズの確定が完了しました");
 
   // ジオメトリは本文（N 段）と前付け（常に 1 段）で分ける。両者は段数・段間以外を共有する。
-  let body_geometry = hlist::PageGeometry {
-    margin_top: config.pdf.margin.top.to_pt(),
-    page_limit: config.pdf.height.to_pt() - config.pdf.margin.bottom.to_pt(),
-    default_font_size,
-    line_height_factor,
-    table_cell_padding: style.table.cell_padding.to_pt(),
-    num_columns: body_columns,
-    column_gap,
-  };
-  let front_geometry = hlist::PageGeometry {
-    num_columns: 1,
-    column_gap: 0.0,
-    ..body_geometry
-  };
+  let (body_geometry, front_geometry) =
+    build_page_geometries(&config, &style, default_font_size, line_height_factor, body_columns, column_gap);
 
   // 本文を 1 回だけページ分割する。これがそのまま最終本文ページになる。各見出しの本文内ページ index も
   // ここから採取する。本文は前付け（タイトルページ・目次）と別系列で 1 から番号付けするため、得られる
@@ -260,38 +248,21 @@ pub(super) fn build_pdf(config_path: &Path) -> miette::Result<BuildSummary> {
   info!(body_page_count, elapsed_ms = elapsed_ms(stage_start), "本文のページ分割が完了しました");
 
   // 前付けブロック（タイトルページ → 目次）を組み立てる。各リージョンは改ページ境界で始まる。
-  let mut front_blocks: Vec<hlist::Block> = Vec::new();
-  if style.title_page.enabled {
-    let metadata = lowering::TitlePageMetadata {
-      title: config.document.title.clone(),
-      author: config.document.author.clone(),
-      date: config.document.date.clone(),
-    };
-    // lower_title_page は末尾に PageBreak を含むため、後続（目次・本文）は次ページから始まる。
-    let title_nodes = lowering::lower_title_page(&metadata, &style.title_page);
-    {
-      let _span = debug_span!("build_blocks", region = "title").entered();
-      front_blocks.extend(layout::build_blocks(
-        title_nodes,
-        &harf_rust_shapers,
-        &metrics,
-        default_font_size,
-        line_height_factor,
-      ));
-    }
-    debug!("タイトルページを生成しました");
-  }
-  if style.toc.enabled {
-    let toc_entries = collect_toc_entries(&doc_nodes, &heading_pages, &style.toc, &style.page_numbering);
-    let toc_spec = build_toc_spec(&style, text_width);
-    let toc_blocks = layout::build_toc_blocks(&toc_spec, &toc_entries, &harf_rust_shapers, &metrics);
-    if !toc_blocks.is_empty() {
-      front_blocks.extend(toc_blocks);
-      // 目次の後で改ページし、本文を次ページから始める（本文区間の独立性を保つ）。
-      front_blocks.push(hlist::Block::PageBreak);
-      debug!(toc_entry_count = toc_entries.len(), "目次を生成しました");
-    }
-  }
+  // タイトルページのメタデータは config 形状から疎結合にするため本体で構築して渡す。
+  let title_metadata = lowering::TitlePageMetadata {
+    title: config.document.title.clone(),
+    author: config.document.author.clone(),
+    date: config.document.date.clone(),
+  };
+  let front_blocks = assemble_front_matter(
+    &doc_nodes,
+    &heading_pages,
+    &title_metadata,
+    &style,
+    &harf_rust_shapers,
+    &metrics,
+    text_width,
+  );
 
   // 前付け（1 段）を本文（N 段）と別に分割し、ページ列として連結する。前付けと本文は段数が異なるため
   // 1 回の break_pages では兼ねられない。連結することで本文ページは後ろの index へ自動的にずれ、内部
@@ -317,19 +288,7 @@ pub(super) fn build_pdf(config_path: &Path) -> miette::Result<BuildSummary> {
 
   // ページ数確定後にヘッダー・フッターを配置する（ページ番号トークンの解決にラベルが必要なため）
   let page_height = config.pdf.height.to_pt();
-  let running_spec = layout::RunningContentSpec {
-    header: running_slots(&style.header, style.header.baseline_offset.to_pt(), true),
-    footer: running_slots(&style.footer, page_height - style.footer.baseline_offset.to_pt(), false),
-    metadata: layout::RunningMetadata {
-      title: config.document.title.clone().unwrap_or_default(),
-      author: config.document.author.clone().unwrap_or_default(),
-      date: config.document.date.clone().unwrap_or_default(),
-    },
-    text_width,
-    page_numbers,
-    // タイトルページ（先頭ページ）にはヘッダー・フッターを描画しない
-    skip_first: style.title_page.enabled,
-  };
+  let running_spec = build_running_spec(&style, &config.document, text_width, page_height, page_numbers);
   layout::build_running_content(&mut pages, &harf_rust_shapers, &metrics, &running_spec);
 
   // PDF しおり用の見出し情報を文書順に集める（CSL 整形で追加された References 見出しも含む）。
@@ -358,6 +317,35 @@ pub(super) fn build_pdf(config_path: &Path) -> miette::Result<BuildSummary> {
 /// ステージ開始時刻からの経過ミリ秒を返す（INFO サマリの `elapsed_ms` 用）。
 fn elapsed_ms(start: Instant) -> u64 { return start.elapsed().as_millis() as u64; }
 
+/// 本文（N 段）と前付け（常に 1 段）の [`hlist::PageGeometry`] を組み立てる。
+///
+/// 両者は段数・段間以外を共有するため、本文側を組んでから前付けは `num_columns` / `column_gap` だけ
+/// 差し替える。
+fn build_page_geometries(
+  config: &read_config::Config,
+  style: &read_style::Style,
+  default_font_size: f32,
+  line_height_factor: f32,
+  body_columns: usize,
+  column_gap: f32,
+) -> (hlist::PageGeometry, hlist::PageGeometry) {
+  let body_geometry = hlist::PageGeometry {
+    margin_top: config.pdf.margin.top.to_pt(),
+    page_limit: config.pdf.height.to_pt() - config.pdf.margin.bottom.to_pt(),
+    default_font_size,
+    line_height_factor,
+    table_cell_padding: style.table.cell_padding.to_pt(),
+    num_columns: body_columns,
+    column_gap,
+  };
+  let front_geometry = hlist::PageGeometry {
+    num_columns: 1,
+    column_gap: 0.0,
+    ..body_geometry
+  };
+  return (body_geometry, front_geometry);
+}
+
 /// Document IR の見出しから PDF しおり用の [`pdf_gen::OutlineEntry`] を文書順に組み立てる。
 ///
 /// テキストは `"{number} {plain title}"`（番号が空なら表題のみ）。見出しの収集は意味側の
@@ -385,6 +373,45 @@ fn heading_label(number: &str, title_plain: &str) -> String {
     return number.to_string();
   }
   return format!("{number} {title_plain}");
+}
+
+/// 前付けブロック（タイトルページ → 目次）を文書順に組み立てて返す。
+///
+/// 各リージョンは改ページ境界で始まる。`lower_title_page` は末尾に `PageBreak` を含むため、後続
+/// （目次・本文）は次ページから始まる。目次の後にも `Block::PageBreak` を積み、本文を次ページから
+/// 始める（本文区間の独立性を保つ）。`title_page` / `toc` がともに無効なら空列を返す。
+fn assemble_front_matter(
+  doc_nodes: &[DocNode],
+  heading_pages: &[usize],
+  title_metadata: &lowering::TitlePageMetadata,
+  style: &read_style::Style,
+  shapers: &HarfRustShapers,
+  metrics: &FontMetrics,
+  text_width: f32,
+) -> Vec<hlist::Block> {
+  // build_blocks 用の既定サイズは style から導出する（呼び出し本体と同じ値）。
+  let default_font_size = style.text.font_size.to_pt();
+  let line_height_factor = style.text.line_height_factor;
+  let mut front_blocks: Vec<hlist::Block> = Vec::new();
+  if style.title_page.enabled {
+    let title_nodes = lowering::lower_title_page(title_metadata, &style.title_page);
+    {
+      let _span = debug_span!("build_blocks", region = "title").entered();
+      front_blocks.extend(layout::build_blocks(title_nodes, shapers, metrics, default_font_size, line_height_factor));
+    }
+    debug!("タイトルページを生成しました");
+  }
+  if style.toc.enabled {
+    let toc_entries = collect_toc_entries(doc_nodes, heading_pages, &style.toc, &style.page_numbering);
+    let toc_spec = build_toc_spec(style, text_width);
+    let toc_blocks = layout::build_toc_blocks(&toc_spec, &toc_entries, shapers, metrics);
+    if !toc_blocks.is_empty() {
+      front_blocks.extend(toc_blocks);
+      front_blocks.push(hlist::Block::PageBreak);
+      debug!(toc_entry_count = toc_entries.len(), "目次を生成しました");
+    }
+  }
+  return front_blocks;
 }
 
 /// 前付け（タイトルページ → 目次）ブロックを単独でページ分割する。
@@ -536,6 +563,32 @@ fn parse_all_sources(
     });
   }
   return Ok(all_nodes);
+}
+
+/// ページ数確定後のヘッダー・フッター配置仕様 [`layout::RunningContentSpec`] を組み立てる。
+///
+/// ヘッダー / フッターの各スロットは [`running_slots`] で構築し（全スロット空なら描画省略）、`skip_first`
+/// でタイトルページ（先頭ページ）への非描画を指示する。`page_numbers` のラベル解決は配置パス側が担う。
+fn build_running_spec(
+  style: &read_style::Style,
+  document: &read_config::DocumentConfig,
+  text_width: f32,
+  page_height: f32,
+  page_numbers: Vec<(String, String)>,
+) -> layout::RunningContentSpec {
+  return layout::RunningContentSpec {
+    header: running_slots(&style.header, style.header.baseline_offset.to_pt(), true),
+    footer: running_slots(&style.footer, page_height - style.footer.baseline_offset.to_pt(), false),
+    metadata: layout::RunningMetadata {
+      title: document.title.clone().unwrap_or_default(),
+      author: document.author.clone().unwrap_or_default(),
+      date: document.date.clone().unwrap_or_default(),
+    },
+    text_width,
+    page_numbers,
+    // タイトルページ（先頭ページ）にはヘッダー・フッターを描画しない
+    skip_first: style.title_page.enabled,
+  };
 }
 
 /// `RunningContentStyle` をヘッダー・フッター配置用の [`layout::RunningSlots`] に変換する。


### PR DESCRIPTION
## 概要

`build_pdf`（`crates/seiran/src/build_pdf.rs`）本体を、パイプライン各ステージの呼び出し列として読めるよう、インライン展開されていた自己完結した塊を 3 つのファイルローカル補助関数へ切り出した。純粋な code-move リファクタで振る舞いは不変。Closes #137。

## 変更内容

`crates/seiran/src/build_pdf.rs` に補助関数を 3 つ追加し、`build_pdf` 本体の該当ブロックを呼び出しに置換した（順序・`info!`/`debug_span!` ログ・早期 return・エラー伝播はそのまま移動）。

- **`assemble_front_matter(...) -> Vec<hlist::Block>`** — タイトルページ（`lower_title_page` → `build_blocks`、末尾 `PageBreak` 込み）+ 目次（`collect_toc_entries` / `build_toc_spec` / `build_toc_blocks` → 末尾 `Block::PageBreak`）の組み立て。`region = "title"` の `debug_span!` と `debug!` ログも内部へ移動。
- **`build_running_spec(...) -> layout::RunningContentSpec`** — ヘッダー/フッターの `running_slots` 呼び出し・`RunningMetadata` 詰め・`skip_first` 判定。`build_running_content` の呼び出しは本体に残す。
- **`build_page_geometries(...) -> (PageGeometry, PageGeometry)`** — 本文（N 段）と前付け（常に 1 段 = `..body_geometry` の spread）のジオメトリ構築。

## 設計上の判断

- **モジュール化せずファイル内関数に留めた**。切り出した塊は `build_pdf` 専用ヘルパで外部再利用がなく、別モジュールに割ると `pub(crate) use` 再エクスポートとインラインテスト分割でパイプラインの筋書きが散る。きれいさ基準では凝集した 1 ファイルが読みやすい（issue のモジュール化は「選択肢・拘束しない」）。
- **フォント初期化列（178 行付近）は本体に残した**。`FontRefs` が `FontData` を、`ShaperDatas`/`ShaperInstances`/`HarfRustShapers`/`FontMetrics` が `FontRefs` を借用する自己参照的な借用連鎖で、ヘルパから戻り値として返せない（self-referential struct になる）。issue の「ローカル束縛に密結合する関数を引数地獄にしてまで切り出さない」の具体例。
- **`assemble_front_matter` の引数は 7 個に抑えた**。`default_font_size` / `line_height_factor` は渡している `style` から導出できる冗長な引数だったため、ヘルパ内で `style.text` から導出するようにして `clippy::too_many_arguments` を `#[allow]` なしで解消した。

## テスト

- `cargo test -p seiran` 緑（既存ユニットテスト 5 件）。pre-push の全クレートテストも緑。
- `cargo clippy`（`clippy::all` deny / `pedantic` warn）警告なし、`cargo +nightly fmt` 済み。
- **出力 PDF の不変性をバイト比較で確認**: PDF に埋め込まれる `Utc::now()` 由来の `CreationDate`/`ModDate`・content-hash の `/ID`・XMP を排除するため、メタデータの日時を一時的に固定したうえで、リファクタ前（`build_pdf.rs` のみ stash）と後を同一クロックでビルドして比較 → 本文のみ（`theorem.sei`）・前付けフル（`toc.sei` + タイトルページ/目次/ヘッダー/フッター/2 段）の両構成で **バイト完全一致**。ログも `elapsed_ms`・総時間を除き一致。

## スコープ外

- ステージの順序・分割アルゴリズム・ログ仕様の変更。
- 前付け（1 段）/本文（N 段）の二系統ジオメトリ設計自体の見直し。

## 関連

- Closes #137
- 親 epic: #136