### PR TITLE
リファクタ: table 環境ハンドラを責務単位の補助関数に分割する

### DIFF
--- a/crates/parser/src/evaluator/environment/table.rs
+++ b/crates/parser/src/evaluator/environment/table.rs
@@ -137,6 +137,69 @@ fn collect_table_opts(view: &EnvironmentView) -> Result<TableOpts, EvalError> {
   });
 }
 
+/// `columns="left center right"` の値を [`ColumnAlign`] の列に変換する
+fn parse_columns_spec(spec: &str, view: &EnvironmentView) -> Result<Vec<ColumnAlign>, EvalError> {
+  let invalid = || EvalError::InvalidOptArgValue {
+    name: "table".to_string(),
+    key: "columns".to_string(),
+    expected: "left / center / right の空白区切り".to_string(),
+    span: view.span().into(),
+  };
+  let tokens: Vec<&str> = spec.split_whitespace().collect();
+  if tokens.is_empty() {
+    return Err(invalid());
+  }
+  return tokens.iter().map(|t| ColumnAlign::from_keyword(t).ok_or_else(invalid)).collect();
+}
+
+/// `widths="auto auto 5cm 0.3 *"` の値を [`ColumnWidth`] の列に変換する
+fn parse_widths_spec(spec: &str, view: &EnvironmentView) -> Result<Vec<ColumnWidth>, EvalError> {
+  let invalid = || EvalError::InvalidOptArgValue {
+    name: "table".to_string(),
+    key: "widths".to_string(),
+    expected: "auto / <num>mm / <num>cm / 0〜1 の比率 / * の空白区切り".to_string(),
+    span: view.span().into(),
+  };
+  let tokens: Vec<&str> = spec.split_whitespace().collect();
+  if tokens.is_empty() {
+    return Err(invalid());
+  }
+  return tokens.iter().map(|t| parse_width_token(t).ok_or_else(invalid)).collect();
+}
+
+/// `widths=` の 1 トークンを [`ColumnWidth`] に変換する
+///
+/// 受理する形式: `auto` / `*` / `<num>mm` / `<num>cm`（サフィックスは大小無視）/
+/// `0` より大きく `1` 以下の小数（本文幅に対する比率）。
+fn parse_width_token(token: &str) -> Option<ColumnWidth> {
+  if token == "auto" {
+    return Some(ColumnWidth::Auto);
+  }
+  if token == "*" {
+    return Some(ColumnWidth::Flex);
+  }
+  let lower = token.to_ascii_lowercase();
+  if let Some(stripped) = lower.strip_suffix("mm") {
+    let value: f32 = stripped.parse().ok()?;
+    if !(value.is_finite() && value > 0.0) {
+      return None;
+    }
+    return Some(ColumnWidth::Fixed(Length::mm(value)));
+  }
+  if let Some(stripped) = lower.strip_suffix("cm") {
+    let value: f32 = stripped.parse().ok()?;
+    if !(value.is_finite() && value > 0.0) {
+      return None;
+    }
+    return Some(ColumnWidth::Fixed(Length::cm(value)));
+  }
+  let ratio: f32 = lower.parse().ok()?;
+  if !(ratio.is_finite() && ratio > 0.0 && ratio <= 1.0) {
+    return None;
+  }
+  return Some(ColumnWidth::Ratio(ratio));
+}
+
 /// 本体走査で収集した行・キャプション情報
 struct TableBody {
   head: Vec<(TableRow, miette::SourceSpan)>,
@@ -206,117 +269,6 @@ fn scan_table_body(view: &EnvironmentView) -> Result<TableBody, EvalError> {
     caption,
     caption_position,
   });
-}
-
-/// 列数を決定し、全行のセル数（`span` 合計）が一致するか検証する
-///
-/// 列数は `columns` / `widths` の明示指定を優先し、両方未指定なら行のセル数（`span` 合計）の
-/// 最大値を採る。`columns` と `widths` の長さが食い違う場合は
-/// [`EvalError::TableColumnsWidthsMismatch`]、列数と一致しない行があれば
-/// [`EvalError::TableRowCellCountMismatch`] を返す。
-fn resolve_column_count(
-  columns_tokens: Option<&[ColumnAlign]>,
-  widths_tokens: Option<&[ColumnWidth]>,
-  head: &[(TableRow, miette::SourceSpan)],
-  rows: &[(TableRow, miette::SourceSpan)],
-  view: &EnvironmentView,
-) -> Result<usize, EvalError> {
-  // 列数の決定: columns / widths の明示指定を優先し、両方未指定なら行のセル数（span 合計）の最大値
-  let column_count = match (columns_tokens, widths_tokens) {
-    (Some(c), Some(w)) => {
-      if c.len() != w.len() {
-        return Err(EvalError::TableColumnsWidthsMismatch {
-          columns: c.len(),
-          widths: w.len(),
-          span: view.span().into(),
-        });
-      }
-      c.len()
-    },
-    (Some(c), None) => c.len(),
-    (None, Some(w)) => w.len(),
-    (None, None) => head.iter().chain(rows.iter()).map(|(row, _)| row_span_sum(row)).max().unwrap_or(0),
-  };
-
-  // 各行のセル数（span 合計）が列数と一致するか検証する
-  for (row, span) in head.iter().chain(rows.iter()) {
-    let actual = row_span_sum(row);
-    if actual != column_count {
-      return Err(EvalError::TableRowCellCountMismatch {
-        expected: column_count,
-        actual,
-        span: *span,
-      });
-    }
-  }
-
-  return Ok(column_count);
-}
-
-/// 行のセル数（`span` 合計）を返す
-fn row_span_sum(row: &TableRow) -> usize { return row.cells.iter().map(|cell| cell.span as usize).sum(); }
-
-/// `columns="left center right"` の値を [`ColumnAlign`] の列に変換する
-fn parse_columns_spec(spec: &str, view: &EnvironmentView) -> Result<Vec<ColumnAlign>, EvalError> {
-  let invalid = || EvalError::InvalidOptArgValue {
-    name: "table".to_string(),
-    key: "columns".to_string(),
-    expected: "left / center / right の空白区切り".to_string(),
-    span: view.span().into(),
-  };
-  let tokens: Vec<&str> = spec.split_whitespace().collect();
-  if tokens.is_empty() {
-    return Err(invalid());
-  }
-  return tokens.iter().map(|t| ColumnAlign::from_keyword(t).ok_or_else(invalid)).collect();
-}
-
-/// `widths="auto auto 5cm 0.3 *"` の値を [`ColumnWidth`] の列に変換する
-fn parse_widths_spec(spec: &str, view: &EnvironmentView) -> Result<Vec<ColumnWidth>, EvalError> {
-  let invalid = || EvalError::InvalidOptArgValue {
-    name: "table".to_string(),
-    key: "widths".to_string(),
-    expected: "auto / <num>mm / <num>cm / 0〜1 の比率 / * の空白区切り".to_string(),
-    span: view.span().into(),
-  };
-  let tokens: Vec<&str> = spec.split_whitespace().collect();
-  if tokens.is_empty() {
-    return Err(invalid());
-  }
-  return tokens.iter().map(|t| parse_width_token(t).ok_or_else(invalid)).collect();
-}
-
-/// `widths=` の 1 トークンを [`ColumnWidth`] に変換する
-///
-/// 受理する形式: `auto` / `*` / `<num>mm` / `<num>cm`（サフィックスは大小無視）/
-/// `0` より大きく `1` 以下の小数（本文幅に対する比率）。
-fn parse_width_token(token: &str) -> Option<ColumnWidth> {
-  if token == "auto" {
-    return Some(ColumnWidth::Auto);
-  }
-  if token == "*" {
-    return Some(ColumnWidth::Flex);
-  }
-  let lower = token.to_ascii_lowercase();
-  if let Some(stripped) = lower.strip_suffix("mm") {
-    let value: f32 = stripped.parse().ok()?;
-    if !(value.is_finite() && value > 0.0) {
-      return None;
-    }
-    return Some(ColumnWidth::Fixed(Length::mm(value)));
-  }
-  if let Some(stripped) = lower.strip_suffix("cm") {
-    let value: f32 = stripped.parse().ok()?;
-    if !(value.is_finite() && value > 0.0) {
-      return None;
-    }
-    return Some(ColumnWidth::Fixed(Length::cm(value)));
-  }
-  let ratio: f32 = lower.parse().ok()?;
-  if !(ratio.is_finite() && ratio > 0.0 && ratio <= 1.0) {
-    return None;
-  }
-  return Some(ColumnWidth::Ratio(ratio));
 }
 
 /// `\head{\row{...} ...}` からヘッダ行を抽出する
@@ -441,6 +393,15 @@ fn extract_row(view: &CommandView) -> Result<TableRow, EvalError> {
   return Ok(TableRow { cells, rule_above });
 }
 
+/// セル内容に強制改行（`\\`）が含まれるかを再帰的に判定する
+fn contains_line_break(nodes: &[InlineNode]) -> bool {
+  return nodes.iter().any(|node| match node {
+    InlineNode::LineBreak => true,
+    InlineNode::Styled { children, .. } | InlineNode::Colored { children, .. } => contains_line_break(children),
+    _ => false,
+  });
+}
+
 /// `&` 分割後の 1 区画を [`TableCell`] に変換する
 ///
 /// 区画の非トリビア要素が `\cell` コマンド 1 つだけなら属性付きセルとして評価し、
@@ -549,14 +510,53 @@ fn trim_cell_content(mut content: Vec<InlineNode>) -> Vec<InlineNode> {
   return content;
 }
 
-/// セル内容に強制改行（`\\`）が含まれるかを再帰的に判定する
-fn contains_line_break(nodes: &[InlineNode]) -> bool {
-  return nodes.iter().any(|node| match node {
-    InlineNode::LineBreak => true,
-    InlineNode::Styled { children, .. } | InlineNode::Colored { children, .. } => contains_line_break(children),
-    _ => false,
-  });
+/// 列数を決定し、全行のセル数（`span` 合計）が一致するか検証する
+///
+/// 列数は `columns` / `widths` の明示指定を優先し、両方未指定なら行のセル数（`span` 合計）の
+/// 最大値を採る。`columns` と `widths` の長さが食い違う場合は
+/// [`EvalError::TableColumnsWidthsMismatch`]、列数と一致しない行があれば
+/// [`EvalError::TableRowCellCountMismatch`] を返す。
+fn resolve_column_count(
+  columns_tokens: Option<&[ColumnAlign]>,
+  widths_tokens: Option<&[ColumnWidth]>,
+  head: &[(TableRow, miette::SourceSpan)],
+  rows: &[(TableRow, miette::SourceSpan)],
+  view: &EnvironmentView,
+) -> Result<usize, EvalError> {
+  // 列数の決定: columns / widths の明示指定を優先し、両方未指定なら行のセル数（span 合計）の最大値
+  let column_count = match (columns_tokens, widths_tokens) {
+    (Some(c), Some(w)) => {
+      if c.len() != w.len() {
+        return Err(EvalError::TableColumnsWidthsMismatch {
+          columns: c.len(),
+          widths: w.len(),
+          span: view.span().into(),
+        });
+      }
+      c.len()
+    },
+    (Some(c), None) => c.len(),
+    (None, Some(w)) => w.len(),
+    (None, None) => head.iter().chain(rows.iter()).map(|(row, _)| row_span_sum(row)).max().unwrap_or(0),
+  };
+
+  // 各行のセル数（span 合計）が列数と一致するか検証する
+  for (row, span) in head.iter().chain(rows.iter()) {
+    let actual = row_span_sum(row);
+    if actual != column_count {
+      return Err(EvalError::TableRowCellCountMismatch {
+        expected: column_count,
+        actual,
+        span: *span,
+      });
+    }
+  }
+
+  return Ok(column_count);
 }
+
+/// 行のセル数（`span` 合計）を返す
+fn row_span_sum(row: &TableRow) -> usize { return row.cells.iter().map(|cell| cell.span as usize).sum(); }
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]

--- a/crates/parser/src/evaluator/environment/table.rs
+++ b/crates/parser/src/evaluator/environment/table.rs
@@ -47,6 +47,64 @@ use crate::evaluator::{
 /// 未知の任意引数キー、揃え / 幅トークンの不正、セル数の不一致、
 /// `\row` の欠如などが発生した場合にエラーを返します。
 pub(super) fn table(view: &EnvironmentView, evaluator: &mut Evaluator) -> Result<Vec<DocNode>, EvalError> {
+  let opts = collect_table_opts(view)?;
+
+  let number =
+    evaluator
+      .registry
+      .increment_with_label(CounterName::Table, opts.label.as_deref(), view.span().into())?;
+
+  if !view.args().is_empty() {
+    return Err(EvalError::ExtraEnvironmentArgument {
+      name: "table".to_string(),
+      span: view.span().into(),
+    });
+  }
+
+  let columns_tokens = opts.columns_spec.as_deref().map(|s| parse_columns_spec(s, view)).transpose()?;
+  let widths_tokens = opts.widths_spec.as_deref().map(|s| parse_widths_spec(s, view)).transpose()?;
+
+  let body = scan_table_body(view)?;
+
+  if body.head.is_empty() && body.rows.is_empty() {
+    return Err(EvalError::MissingEnvironmentArgument {
+      name: "table".to_string(),
+      expected: "\\row コマンド".to_string(),
+      span: view.span().into(),
+    });
+  }
+
+  let column_count =
+    resolve_column_count(columns_tokens.as_deref(), widths_tokens.as_deref(), &body.head, &body.rows, view)?;
+
+  let columns = columns_tokens.unwrap_or_else(|| vec![ColumnAlign::Left; column_count]);
+  let widths = widths_tokens.unwrap_or_else(|| vec![ColumnWidth::Auto; column_count]);
+
+  return Ok(vec![DocNode::Table {
+    columns,
+    widths,
+    head: body.head.into_iter().map(|(row, _)| row).collect(),
+    rows: body.rows.into_iter().map(|(row, _)| row).collect(),
+    caption: body.caption,
+    caption_position: body.caption_position,
+    label: opts.label,
+    number,
+    breakable: opts.breakable,
+  }]);
+}
+
+/// `table` 環境の任意引数を集約した構造体
+struct TableOpts {
+  columns_spec: Option<String>,
+  widths_spec: Option<String>,
+  label: Option<String>,
+  breakable: bool,
+}
+
+/// `table` の任意引数（`columns` / `widths` / `label` / `breakable`）を収集してスカラー化する
+///
+/// 既定では `breakable` は `true`（改ページによる分割を許可）。
+fn collect_table_opts(view: &EnvironmentView) -> Result<TableOpts, EvalError> {
   let opt_args = collect_environment_opt_args(
     view,
     &[
@@ -71,18 +129,28 @@ pub(super) fn table(view: &EnvironmentView, evaluator: &mut Evaluator) -> Result
     }
   }
 
-  let number = evaluator.registry.increment_with_label(CounterName::Table, label.as_deref(), view.span().into())?;
+  return Ok(TableOpts {
+    columns_spec,
+    widths_spec,
+    label,
+    breakable,
+  });
+}
 
-  if !view.args().is_empty() {
-    return Err(EvalError::ExtraEnvironmentArgument {
-      name: "table".to_string(),
-      span: view.span().into(),
-    });
-  }
+/// 本体走査で収集した行・キャプション情報
+struct TableBody {
+  head: Vec<(TableRow, miette::SourceSpan)>,
+  rows: Vec<(TableRow, miette::SourceSpan)>,
+  caption: Option<Vec<InlineNode>>,
+  caption_position: CaptionPosition,
+}
 
-  let columns_tokens = columns_spec.as_deref().map(|s| parse_columns_spec(s, view)).transpose()?;
-  let widths_tokens = widths_spec.as_deref().map(|s| parse_widths_spec(s, view)).transpose()?;
-
+/// 本体から `\head` / `\row` / `\caption` を走査して [`TableBody`] に収集する
+///
+/// `\head` / `\caption` は高々 1 回（重複は [`EvalError::DuplicateCommandInEnvironment`]）。
+/// 行はソース位置とともに収集し、列数確定後のセル数検証に使う。キャプション位置は、
+/// `\caption` が最初の行（`\head` / `\row`）よりソース上で先に現れた場合のみ `Top`。
+fn scan_table_body(view: &EnvironmentView) -> Result<TableBody, EvalError> {
   let source = view.source();
   // 行はソース位置とともに収集し、列数確定後にセル数を検証する
   let mut head: Vec<(TableRow, miette::SourceSpan)> = Vec::new();
@@ -132,16 +200,29 @@ pub(super) fn table(view: &EnvironmentView, evaluator: &mut Evaluator) -> Result
     }
   }
 
-  if head.is_empty() && rows.is_empty() {
-    return Err(EvalError::MissingEnvironmentArgument {
-      name: "table".to_string(),
-      expected: "\\row コマンド".to_string(),
-      span: view.span().into(),
-    });
-  }
+  return Ok(TableBody {
+    head,
+    rows,
+    caption,
+    caption_position,
+  });
+}
 
+/// 列数を決定し、全行のセル数（`span` 合計）が一致するか検証する
+///
+/// 列数は `columns` / `widths` の明示指定を優先し、両方未指定なら行のセル数（`span` 合計）の
+/// 最大値を採る。`columns` と `widths` の長さが食い違う場合は
+/// [`EvalError::TableColumnsWidthsMismatch`]、列数と一致しない行があれば
+/// [`EvalError::TableRowCellCountMismatch`] を返す。
+fn resolve_column_count(
+  columns_tokens: Option<&[ColumnAlign]>,
+  widths_tokens: Option<&[ColumnWidth]>,
+  head: &[(TableRow, miette::SourceSpan)],
+  rows: &[(TableRow, miette::SourceSpan)],
+  view: &EnvironmentView,
+) -> Result<usize, EvalError> {
   // 列数の決定: columns / widths の明示指定を優先し、両方未指定なら行のセル数（span 合計）の最大値
-  let column_count = match (&columns_tokens, &widths_tokens) {
+  let column_count = match (columns_tokens, widths_tokens) {
     (Some(c), Some(w)) => {
       if c.len() != w.len() {
         return Err(EvalError::TableColumnsWidthsMismatch {
@@ -169,20 +250,7 @@ pub(super) fn table(view: &EnvironmentView, evaluator: &mut Evaluator) -> Result
     }
   }
 
-  let columns = columns_tokens.unwrap_or_else(|| vec![ColumnAlign::Left; column_count]);
-  let widths = widths_tokens.unwrap_or_else(|| vec![ColumnWidth::Auto; column_count]);
-
-  return Ok(vec![DocNode::Table {
-    columns,
-    widths,
-    head: head.into_iter().map(|(row, _)| row).collect(),
-    rows: rows.into_iter().map(|(row, _)| row).collect(),
-    caption,
-    caption_position,
-    label,
-    number,
-    breakable,
-  }]);
+  return Ok(column_count);
 }
 
 /// 行のセル数（`span` 合計）を返す


### PR DESCRIPTION
## 概要

`table` 環境ハンドラ（`crates/parser/src/evaluator/environment/table.rs`）本体に同居していた連続フェーズを、ファイルローカルな補助関数 3 つへ切り出し、`table()` を各フェーズの呼び出し列として読めるようにした。純粋な code-move リファクタで振る舞いは不変。

## 変更内容

`table.rs` に補助関数 3 つと集約構造体 2 つを追加し、`table()` 本体の該当ブロックを呼び出しへ置換した（順序・早期 return・エラー伝播・`span` / 文面はそのまま移動）。

- **`collect_table_opts(view) -> TableOpts`** — opt 引数（`columns` / `widths` / `label` / `breakable`）の収集とスカラー化。`TableOpts` に集約。
- **`scan_table_body(view) -> TableBody`** — 本体走査（`\head` / `\row` / `\caption` の検出・重複検証・キャプション位置判定）。`TableBody` に集約。
- **`resolve_column_count(...) -> usize`** — 列数決定（columns/widths 明示優先・両方未指定なら span 合計の最大）＋全行セル数検証。引数は `Option<&[T]>` スライスにして `clippy::ref_option` を回避。

兄弟ハンドラ `figure.rs` の `ImageArgs` 慣用に揃え、構造体を返すフェーズ関数とした。

## 設計上の判断

- **モジュール化せずファイル内関数に留めた**。column-spec パーサは小さく、`table()` のクリーンさはフェーズ関数で得られる。モジュール化（`table/columns.rs`）は再エクスポートとインラインテスト分割の boilerplate を増やすだけで orchestrator の可読性に寄与しないため、同 epic 先行 #141 の判断に倣い見送った。
- **エラーの発火順序を厳守**: opt 収集 → カウンタ発番 → 引数空チェック → spec パース → 本体走査 → 行欠如チェック → 列数決定+セル数検証。最初に当たるエラーが従来と同一になるよう各ブロックをそのまま移動した。

## テスト（振る舞い不変の担保）

- `cargo test -p parser` 緑（table.rs インラインテスト 20 件超を含む）。
- `cargo test --workspace` 全クレート緑、`cargo clippy --workspace --all-targets` 警告ゼロ、`cargo +nightly fmt` 済み。
- **出力 PDF の不変性をバイト比較で確認**: メタデータの `Utc::now()` を一時固定し、リファクタ前（`table.rs` のみ stash）と後で `tests/text/table.sei` をビルド → SHA-256 完全一致。

## スコープ外

- `extract_head` / `extract_row` / `extract_caption` など既存ヘルパの再設計。
- columns/widths セマンティクス・列幅/整列の挙動。
- モジュール（`table/<child>.rs`）への昇格。

## 関連

- Closes #138
- 親 epic: #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)