### PR TITLE
数式: evaluate_grid の行末マーカー検出・検証を補助関数に分割する

### DIFF
--- a/crates/parser/src/evaluator/environment/math/math_grid.rs
+++ b/crates/parser/src/evaluator/environment/math/math_grid.rs
@@ -95,12 +95,7 @@ pub(crate) fn evaluate_grid(
             });
           }
           // 行末マーカーの後ろに列が続くなら、マーカーは行末になく不正
-          if let Some(span) = current_notag {
-            return Err(EvalError::NotagNotAtRowEnd { span });
-          }
-          if let Some((_, span)) = &current_label {
-            return Err(EvalError::RowLabelNotAtRowEnd { span: *span });
-          }
+          ensure_markers_at_row_end(current_notag.as_ref(), current_label.as_ref())?;
           current_row.push(evaluate_math_elements(source, &current_cell)?);
           current_cell.clear();
           continue;
@@ -127,55 +122,14 @@ pub(crate) fn evaluate_grid(
       }
     }
 
-    // 行末マーカー `\notag` / `\label{...}` の検出（CommandCall ノード）
-    if let GreenElement::Node(node) = *child
-      && node.kind == SyntaxKind::CommandCall
-    {
-      let view = CommandView::new(node, source);
-      if view.name() == "notag" {
-        let span: SourceSpan = node.span.into();
-        if !row_markers_allowed {
-          return Err(EvalError::NotagNotSupported { span });
-        }
-        // `\notag` は引数を取らない（`\notag{...}` が後続の中身を飲み込むのを防ぐ）
-        if !view.args_is_empty() || view.opt_args_count() > 0 {
-          return Err(EvalError::NotagNotAtRowEnd { span });
-        }
-        // 1 行に `\notag` は 1 つだけ
-        if current_notag.is_some() {
-          return Err(EvalError::NotagNotAtRowEnd { span });
-        }
-        current_notag = Some(span);
-        continue;
-      }
-      if view.name() == "label" {
-        let span: SourceSpan = node.span.into();
-        if !row_markers_allowed {
-          return Err(EvalError::RowLabelNotSupported { span });
-        }
-        // `\label` は必須引数 1 個（ラベル名）のみ。引数過不足・任意引数付きは不正
-        if view.args_count() != 1 || view.opt_args_count() > 0 {
-          return Err(EvalError::RowLabelNotAtRowEnd { span });
-        }
-        // 1 行に `\label` は 1 つだけ
-        if current_label.is_some() {
-          return Err(EvalError::RowLabelNotAtRowEnd { span });
-        }
-        let first_arg = view.first_arg().ok_or(EvalError::RowLabelNotAtRowEnd { span })?;
-        let label = extract_text_content(source, first_arg).trim().to_string();
-        current_label = Some((label, span));
-        continue;
-      }
+    // 行末マーカー `\notag` / `\label{...}` を検出したら走査ローカル状態へ取り込む
+    if try_take_row_marker(child, source, row_markers_allowed, &mut current_notag, &mut current_label)? {
+      continue;
     }
 
     // 行末マーカーの後ろに意味のある要素が来たら行末ではない（末尾空白等のトリビアは許容）
     if !is_trivia_element(child) {
-      if let Some(span) = current_notag {
-        return Err(EvalError::NotagNotAtRowEnd { span });
-      }
-      if let Some((_, span)) = &current_label {
-        return Err(EvalError::RowLabelNotAtRowEnd { span: *span });
-      }
+      ensure_markers_at_row_end(current_notag.as_ref(), current_label.as_ref())?;
     }
 
     current_cell.push(*child);
@@ -201,6 +155,111 @@ fn take_row_label(current_label: &mut Option<(String, SourceSpan)>) -> (Option<S
     Some((label, span)) => (Some(label), Some(span)),
     None => (None, None),
   };
+}
+
+/// 立っている行末マーカーの後ろに意味のある要素が続いていないか検証する
+///
+/// 列区切り `&` や非トリビア要素がマーカーの後に現れたら、そのマーカーは行末になく不正。
+/// `\notag` を先に、続いて `\label` を検査して [`EvalError::NotagNotAtRowEnd`] /
+/// [`EvalError::RowLabelNotAtRowEnd`] を返す。
+fn ensure_markers_at_row_end(
+  current_notag: Option<&SourceSpan>,
+  current_label: Option<&(String, SourceSpan)>,
+) -> Result<(), EvalError> {
+  if let Some(span) = current_notag {
+    return Err(EvalError::NotagNotAtRowEnd { span: *span });
+  }
+  if let Some((_, span)) = current_label {
+    return Err(EvalError::RowLabelNotAtRowEnd { span: *span });
+  }
+  return Ok(());
+}
+
+/// 行末マーカー `\notag` / `\label{...}` を検出し、走査ローカル状態へ取り込む
+///
+/// `child` が `\notag` / `\label` の `CommandCall` ノードならそれぞれの検証を行って
+/// `current_notag` / `current_label` を立て、`Ok(true)`（呼び出し側は `continue`）を返す。
+/// それ以外の要素は `Ok(false)` を返し、呼び出し側はセル要素として扱う。
+fn try_take_row_marker(
+  child: &GreenElement,
+  source: &str,
+  row_markers_allowed: bool,
+  current_notag: &mut Option<SourceSpan>,
+  current_label: &mut Option<(String, SourceSpan)>,
+) -> Result<bool, EvalError> {
+  let GreenElement::Node(node) = *child else {
+    return Ok(false);
+  };
+  if node.kind != SyntaxKind::CommandCall {
+    return Ok(false);
+  }
+  let view = CommandView::new(node, source);
+  let span: SourceSpan = node.span.into();
+  match view.name() {
+    "notag" => {
+      take_notag_marker(&view, span, row_markers_allowed, current_notag)?;
+      return Ok(true);
+    },
+    "label" => {
+      take_label_marker(&view, source, span, row_markers_allowed, current_label)?;
+      return Ok(true);
+    },
+    _ => return Ok(false),
+  }
+}
+
+/// 行末マーカー `\notag` を検証して走査ローカル状態 `current_notag` を立てる
+///
+/// `row_markers_allowed` が `false` の環境では [`EvalError::NotagNotSupported`]。`\notag` は引数を
+/// 取らないため引数付き・任意引数付き、または 1 行に複数現れた場合は [`EvalError::NotagNotAtRowEnd`]。
+fn take_notag_marker(
+  view: &CommandView,
+  span: SourceSpan,
+  row_markers_allowed: bool,
+  current_notag: &mut Option<SourceSpan>,
+) -> Result<(), EvalError> {
+  if !row_markers_allowed {
+    return Err(EvalError::NotagNotSupported { span });
+  }
+  // `\notag` は引数を取らない（`\notag{...}` が後続の中身を飲み込むのを防ぐ）
+  if !view.args_is_empty() || view.opt_args_count() > 0 {
+    return Err(EvalError::NotagNotAtRowEnd { span });
+  }
+  // 1 行に `\notag` は 1 つだけ
+  if current_notag.is_some() {
+    return Err(EvalError::NotagNotAtRowEnd { span });
+  }
+  *current_notag = Some(span);
+  return Ok(());
+}
+
+/// 行末マーカー `\label{...}` を検証してラベル文字列を抽出し、走査ローカル状態 `current_label` を立てる
+///
+/// `row_markers_allowed` が `false` の環境では [`EvalError::RowLabelNotSupported`]。`\label` は必須引数
+/// 1 個（ラベル名）のみで、引数過不足・任意引数付き、または 1 行に複数現れた場合は
+/// [`EvalError::RowLabelNotAtRowEnd`]。
+fn take_label_marker(
+  view: &CommandView,
+  source: &str,
+  span: SourceSpan,
+  row_markers_allowed: bool,
+  current_label: &mut Option<(String, SourceSpan)>,
+) -> Result<(), EvalError> {
+  if !row_markers_allowed {
+    return Err(EvalError::RowLabelNotSupported { span });
+  }
+  // `\label` は必須引数 1 個（ラベル名）のみ。引数過不足・任意引数付きは不正
+  if view.args_count() != 1 || view.opt_args_count() > 0 {
+    return Err(EvalError::RowLabelNotAtRowEnd { span });
+  }
+  // 1 行に `\label` は 1 つだけ
+  if current_label.is_some() {
+    return Err(EvalError::RowLabelNotAtRowEnd { span });
+  }
+  let first_arg = view.first_arg().ok_or(EvalError::RowLabelNotAtRowEnd { span })?;
+  let label = extract_text_content(source, first_arg).trim().to_string();
+  *current_label = Some((label, span));
+  return Ok(());
 }
 
 /// 採番の粒度


### PR DESCRIPTION
## 変更内容

`evaluate_grid`（`crates/parser/src/evaluator/environment/math/math_grid.rs`）の区切りループに埋め込まれていた行末マーカー（`\notag` / `\label`）の検出・検証ロジックを、責務単位のファイル内 private 関数へ切り出した。**純粋リファクタで振る舞いは不変**（エラーの発火条件 / span / 文面、`current_notag` / `current_label` の状態遷移、トリビア許容をすべて維持）。

切り出した関数:

- `try_take_row_marker` — `CommandCall` ノードを判定し `\notag` / `\label` を各検証関数へディスパッチ。消費したら `Ok(true)`（呼び出し側は `continue`）、それ以外は `Ok(false)`。
- `take_notag_marker` — `\notag` の検証（非許可環境 / 引数付き / 1 行複数）と `current_notag` 設定。
- `take_label_marker` — `\label` の検証・ラベル文字列抽出と `current_label` 設定。
- `ensure_markers_at_row_end` — 行末以外にマーカーが残る不正の共通ガード。**Ampersand アームと末尾ガードに重複していた検査を 1 箇所へ集約**。

これにより `evaluate_grid` 本体（107 → 約 73 行）は「セル / 行を区切りつつ走査する」流れとして読めるようになり、マーカー処理は単一責務の関数に分離された。

## 設計上の判断

- **ファイル内 private 関数に留めた**（`math_grid/marker.rs` への昇格はしない）。マーカー helper は `&mut current_notag` / `&mut current_label` という走査ローカル状態に密結合し、かつ `evaluate_grid` 1 箇所からしか呼ばれず小さい。CLAUDE.md の「可視性を緩めてまで無理に分割しない」「密結合した塊は無理にモジュール化しない」「判断基準は行数でなくきれいさ」に従い、可視性を据え置いた。`math_grid/` ディレクトリ化は #140（`evaluate_math_env`）を束ねる場合に再検討する。
- `ensure_markers_at_row_end` は `clippy::ref_option`（pedantic）回避のため引数を `Option<&...>` とし、呼び出し側で `.as_ref()` を渡す。

## テスト

- `cargo test -p parser` 緑（本ファイル内の分割テスト＋ align / gather / equation 等の数式テストが不変）。
- `cargo test`（ワークスペース全体）緑。
- `cargo clippy -p parser --all-targets` 警告なし・`cargo +nightly fmt` 済み。

## スコープ外

- 行末マーカーの構文・セマンティクス変更。
- `evaluate_math_env`（#140）の末尾行処理・採番。
- `math_grid/` ディレクトリ化。

## 関連

Closes #139
