### PR TITLE
組版: 箇条書きのネスト深さに応じたマーカー自動変化

### DIFF
--- a/crates/lowering/src/lib.rs
+++ b/crates/lowering/src/lib.rs
@@ -126,6 +126,12 @@ pub struct LoweringContext<'a> {
   ///
   /// `\image[downsample=...]` の per-image 上書きが無いときの既定値。
   pub image_downsample: bool,
+  /// 箇条書き（`itemize` / `enumerate`）のネスト深さ（0 = 最上位）
+  ///
+  /// [`crate::list::lower_list`] がマーカーの見た目を段ごとに切り替えるために参照する。
+  /// リスト項目の内容を lower する際に [`LoweringContext::with_list_depth`] で +1 した文脈を
+  /// 渡すことで、item 内容中のネストしたリストが深さ +1 として lower される。
+  pub list_depth: usize,
 }
 
 impl<'a> LoweringContext<'a> {
@@ -144,6 +150,8 @@ impl<'a> LoweringContext<'a> {
       // （read_config::ImageConfig::default と同値）。テストはこの既定をそのまま使う。
       image_max_dpi: 300,
       image_downsample: true,
+      // 文書のトップレベルは深さ 0。リストに入るたび with_list_depth で +1 する。
+      list_depth: 0,
     };
   }
 
@@ -170,6 +178,7 @@ impl<'a> LoweringContext<'a> {
       first_line_indent: self.first_line_indent,
       image_max_dpi: self.image_max_dpi,
       image_downsample: self.image_downsample,
+      list_depth: self.list_depth,
     };
   }
 
@@ -186,6 +195,24 @@ impl<'a> LoweringContext<'a> {
       first_line_indent,
       image_max_dpi: self.image_max_dpi,
       image_downsample: self.image_downsample,
+      list_depth: self.list_depth,
+    };
+  }
+
+  /// 箇条書きのネスト深さだけを差し替えた派生文脈を返す
+  ///
+  /// `style` 参照・その他フィールドは共有したまま `list_depth` のみ上書きする。
+  /// [`crate::list::lower_list`] がリスト項目の内容を lower する際に深さ +1 の文脈を渡し、
+  /// item 内容中のネストしたリストへ深さを伝播させるのに使う。
+  #[must_use]
+  pub fn with_list_depth(&self, list_depth: usize) -> LoweringContext<'a> {
+    return LoweringContext {
+      style: self.style,
+      body_font_kind: self.body_font_kind,
+      first_line_indent: self.first_line_indent,
+      image_max_dpi: self.image_max_dpi,
+      image_downsample: self.image_downsample,
+      list_depth,
     };
   }
 

--- a/crates/lowering/src/list.rs
+++ b/crates/lowering/src/list.rs
@@ -1,25 +1,45 @@
 //! リスト（`DocNode::List`）の lowering
 
 use document::ListItem;
+use read_style::NumberStyle;
 
 use super::{LoweringContext, LoweringError, lower_nodes};
 use crate::layout_node::{LayoutNode, TextStyle};
 
+/// ネスト段（深さ 1 以上）の unordered マーカー系列（LaTeX itemize 準拠）
+///
+/// 深さ `d >= 1` のとき `(d - 1) % 3` で引く。en dash → asterisk → middle dot を循環し、
+/// 5 段目（深さ 4）は 2 段目（深さ 1）と同じ `–` に戻る。
+const NESTED_UNORDERED_MARKERS: [&str; 3] = ["–", "*", "·"];
+
+/// ネスト段（深さ 1 以上）の ordered マーカー系列（番号書式 + 装飾テンプレート）
+///
+/// 各要素は `(番号書式, "{number}" を含むテンプレート)`。深さ `d >= 1` のとき `(d - 1) % 3` で引き、
+/// `(a)`（小文字英字 + 丸括弧）→ `i.`（小文字ローマ数字）→ `A.`（大文字英字）を循環する。
+const NESTED_ORDERED_FORMATS: [(NumberStyle, &str); 3] = [
+  (NumberStyle::AlphaLower, "({number})"),
+  (NumberStyle::RomanLower, "{number}."),
+  (NumberStyle::AlphaUpper, "{number}."),
+];
+
 /// リストをレイアウトノードに変換する
 ///
-/// ## TODO
-///
-/// - [ ] リストのネスト対応（ネストレベルに応じたインデント量の変更）
+/// マーカーの見た目は `ctx.list_depth`（ネスト深さ、0 = 最上位）に応じて自動的に切り替わる。
+/// 最上位は `style.list` の設定（`unordered_marker` / `ordered_marker_format`）をそのまま使い、
+/// 1 段以上ネストした段は [`NESTED_UNORDERED_MARKERS`] / [`NESTED_ORDERED_FORMATS`] の固定系列を
+/// `(depth - 1) % 3` で循環的に引く。字下げ量（インデント）は深さに依らず `VBox.indent` で表す。
 pub(super) fn lower_list(
   ctx: &LoweringContext,
   ordered: bool,
   items: &[ListItem],
 ) -> Result<Vec<LayoutNode>, LoweringError> {
   let list_style = &ctx.style.list;
+  let depth = ctx.list_depth;
   let mut result = Vec::new();
 
   // 項目内容には本文の段落先頭字下げを波及させない（マーカー直後への字下げを避ける）。
-  let item_ctx = ctx.with_first_line_indent(types::Length::pt(0.0));
+  // 同時にネスト深さを +1 して渡し、item 内容中のネストしたリストが深さ +1 で lower されるようにする。
+  let item_ctx = ctx.with_first_line_indent(types::Length::pt(0.0)).with_list_depth(depth + 1);
 
   let marker_style = TextStyle {
     font_size: ctx.default_font_size(),
@@ -28,13 +48,22 @@ pub(super) fn lower_list(
   };
 
   for (i, item) in items.iter().enumerate() {
-    // マーカーの生成
-    // TODO: ネストレベルに応じたマーカーの変更
-    let marker = if ordered {
-      format!("{} ", list_style.ordered_marker_format.replace("{number}", &(i + 1).to_string()))
+    // マーカーの生成。将来 `\item[override]` の個別上書きを入れる場合は、この深さ別の自動選択の
+    // 前段で上書き指定を優先する分岐を挿す（上書きが自動マーカーより優先される）。
+    let n = (i + 1) as u32;
+    let marker_body = if ordered {
+      if depth == 0 {
+        list_style.ordered_marker_format.replace("{number}", &n.to_string())
+      } else {
+        let (number_style, template) = NESTED_ORDERED_FORMATS[(depth - 1) % NESTED_ORDERED_FORMATS.len()];
+        template.replace("{number}", &number_style.render(n))
+      }
+    } else if depth == 0 {
+      list_style.unordered_marker.clone()
     } else {
-      format!("{} ", list_style.unordered_marker)
+      NESTED_UNORDERED_MARKERS[(depth - 1) % NESTED_UNORDERED_MARKERS.len()].to_string()
     };
+    let marker = format!("{marker_body} ");
 
     // マーカー + 内容。左インデントは VBox.indent（ブロック単位）で表し、折り返し行・
     // ネストにも一律適用する。マーカーは先頭行の行頭インラインとして置く。
@@ -201,5 +230,105 @@ mod tests {
 
     // Assert
     assert!(nodes.is_empty());
+  }
+
+  /// 種別（ordered フラグ）の列から、各段 1 項目のネストしたリストの items を構築する
+  ///
+  /// `kinds[0]` は最上位リストの ordered フラグ。返り値は最上位リストの `items` で、
+  /// 呼び出し側は `lower_list(ctx, kinds[0], &items)` で lower する。各段は本文 1 段落と、
+  /// 最深でなければ次段のリスト（ordered フラグは `kinds[1]`）を 1 つ持つ。
+  fn build_nested_items(kinds: &[bool]) -> Vec<ListItem> {
+    let mut content = vec![DocNode::Paragraph(vec![InlineNode::Text("x".to_string())])];
+    if kinds.len() > 1 {
+      content.push(DocNode::List {
+        ordered: kinds[1],
+        items: build_nested_items(&kinds[1..]),
+      });
+    }
+    return vec![ListItem::new(content)];
+  }
+
+  /// item `VBox` の子から、ネストしたリストの先頭項目 `VBox` を取り出す
+  ///
+  /// 段落は `VBox` にならないため、子のうち最初の `VBox` がネストしたリストの item に相当する。
+  fn first_nested_vbox(node: &LayoutNode) -> &LayoutNode {
+    let LayoutNode::VBox { children, .. } = node else {
+      panic!("item は VBox であるべき: {node:?}");
+    };
+    return children
+      .iter()
+      .find(|c| matches!(c, LayoutNode::VBox { .. }))
+      .expect("ネストしたリストの item VBox があるはず");
+  }
+
+  /// ネストしたリストを `depth` 段辿り、各段の先頭項目のマーカー文字列を外→内の順で集める
+  fn markers_along_chain(nodes: &[LayoutNode], depth: usize) -> Vec<String> {
+    let mut cur = &nodes[0];
+    let mut markers = vec![marker_of(cur).0.to_string()];
+    for _ in 1..depth {
+      cur = first_nested_vbox(cur);
+      markers.push(marker_of(cur).0.to_string());
+    }
+    return markers;
+  }
+
+  #[test]
+  fn nested_unordered_markers_vary_by_depth() {
+    // Arrange — 3 段ネストした itemize（全段 unordered）
+    let style = ReadStyle::default();
+    let ctx = LoweringContext::new(&style);
+    let kinds = [false, false, false];
+    let items = build_nested_items(&kinds);
+
+    // Act
+    let nodes = lower_list(&ctx, kinds[0], &items).expect("失敗しない");
+
+    // Assert — • → – → *（AC#1）
+    assert_eq!(markers_along_chain(&nodes, 3), vec!["• ", "– ", "* "]);
+  }
+
+  #[test]
+  fn nested_ordered_markers_vary_by_depth() {
+    // Arrange — 3 段ネストした enumerate（全段 ordered）
+    let style = ReadStyle::default();
+    let ctx = LoweringContext::new(&style);
+    let kinds = [true, true, true];
+    let items = build_nested_items(&kinds);
+
+    // Act
+    let nodes = lower_list(&ctx, kinds[0], &items).expect("失敗しない");
+
+    // Assert — 1. → (a) → i.（AC#2）
+    assert_eq!(markers_along_chain(&nodes, 3), vec!["1. ", "(a) ", "i. "]);
+  }
+
+  #[test]
+  fn mixed_nesting_advances_each_kind_by_depth() {
+    // Arrange — itemize > enumerate > itemize の混在ネスト（AC#4）
+    let style = ReadStyle::default();
+    let ctx = LoweringContext::new(&style);
+    let kinds = [false, true, false];
+    let items = build_nested_items(&kinds);
+
+    // Act
+    let nodes = lower_list(&ctx, kinds[0], &items).expect("失敗しない");
+
+    // Assert — 外 itemize は深さ 0 の •、中 enumerate は深さ 1 の (a)、内 itemize は深さ 2 の *
+    assert_eq!(markers_along_chain(&nodes, 3), vec!["• ", "(a) ", "* "]);
+  }
+
+  #[test]
+  fn unordered_marker_sequence_cycles_after_fourth_level() {
+    // Arrange — 5 段ネストした itemize。5 段目（深さ 4）は 2 段目（深さ 1）の – に戻る
+    let style = ReadStyle::default();
+    let ctx = LoweringContext::new(&style);
+    let kinds = [false; 5];
+    let items = build_nested_items(&kinds);
+
+    // Act
+    let nodes = lower_list(&ctx, kinds[0], &items).expect("失敗しない");
+
+    // Assert — • → – → * → · → –（循環）
+    assert_eq!(markers_along_chain(&nodes, 5), vec!["• ", "– ", "* ", "· ", "– "]);
   }
 }

--- a/crates/lowering/tests/smoke.rs
+++ b/crates/lowering/tests/smoke.rs
@@ -6,7 +6,7 @@
 
 use std::{collections::HashSet, path::PathBuf};
 
-use lowering::LoweringContext;
+use lowering::{LayoutNode, LoweringContext};
 use parser::parse_source;
 use read_style::Style;
 
@@ -65,6 +65,53 @@ fn smoke_ref_fixture() { smoke_through_lowering("ref"); }
 
 #[test]
 fn smoke_itemize_fixture() { smoke_through_lowering("itemize"); }
+
+/// `tests/text/<name>.sei` を parse → lower し、レイアウトノード列を返すヘルパ
+fn lower_fixture(name: &str) -> Vec<LayoutNode> {
+  let path = fixture_path(name);
+  let content =
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("フィクスチャの読み込みに失敗: {}: {e}", path.display()));
+  let style = Style::default();
+  let doc_nodes = parse_source(&content, &path.display().to_string(), &style, &HashSet::new())
+    .unwrap_or_else(|e| panic!("parse_source 失敗 ({name}): {e:?}"));
+  let ctx = LoweringContext::new(&style);
+  return lowering::lower_nodes(&ctx, &doc_nodes).unwrap_or_else(|e| panic!("lower_nodes 失敗 ({name}): {e:?}"));
+}
+
+/// レイアウト木を再帰的に辿り、リスト項目の先頭に置かれるマーカー文字列を集める
+///
+/// `lower_list` は各項目 `VBox` の先頭に `Text(marker, _)` を置く。ここでは
+/// 「先頭の子が `Text` である `VBox`」の先頭文字列を収集し、深さ別マーカーの検証に使う。
+fn collect_item_markers(nodes: &[LayoutNode], out: &mut Vec<String>) {
+  for node in nodes {
+    match node {
+      LayoutNode::VBox { children, .. } => {
+        if let Some(LayoutNode::Text(text, _)) = children.first() {
+          out.push(text.clone());
+        }
+        collect_item_markers(children, out);
+      },
+      LayoutNode::HBox { children, .. } => collect_item_markers(children, out),
+      _ => {},
+    }
+  }
+}
+
+#[test]
+fn itemize_fixture_produces_depth_varying_markers() {
+  // Arrange — ネストを含む itemize フィクスチャを parse → lower する
+  let nodes = lower_fixture("itemize");
+
+  // Act — レイアウト木からリスト項目のマーカー文字列を集める
+  let mut markers = Vec::new();
+  collect_item_markers(&nodes, &mut markers);
+
+  // Assert — parse → lower を通した全パイプラインで、深さ別マーカーが実際に現れる。
+  // unordered は • → – → *、ordered は 1. → (a) → i. がそれぞれ生成される。
+  for expected in ["• ", "– ", "* ", "1. ", "(a) ", "i. "] {
+    assert!(markers.iter().any(|m| m == expected), "マーカー {expected:?} が見つからない: {markers:?}");
+  }
+}
 
 #[test]
 fn smoke_table_fixture() { smoke_through_lowering("table"); }

--- a/tests/text/itemize.sei
+++ b/tests/text/itemize.sei
@@ -20,4 +20,48 @@ itemize 環境（順序なしリスト）と enumerate 環境（順序付きリ�
 \item{3 番目の手順。}
 \end{enumerate}
 
+\section{ネストした箇条書き}
+
+リストをネストすると、深さに応じてマーカーの見た目が自動的に変わることを確認する。
+順序なしリストを 3 段ネストすると、マーカーは 1 段目から順に「黒丸・en dash・アスタリスク」と
+変化する。
+
+\begin{itemize}
+\item{1 段目の項目。マーカーは黒丸。
+\begin{itemize}
+\item{2 段目の項目。マーカーは en dash。
+\begin{itemize}
+\item{3 段目の項目。マーカーはアスタリスク。}
+\end{itemize}
+}
+\item{2 段目のもう 1 つの項目。}
+\end{itemize}
+}
+\end{itemize}
+
+順序付きリストを 3 段ネストすると、番号書式が「算用数字・小文字英字（丸括弧）・小文字ローマ数字」と
+段ごとに変化する。
+
+\begin{enumerate}
+\item{1 段目の手順。番号は算用数字。
+\begin{enumerate}
+\item{2 段目の手順。番号は小文字英字の丸括弧。
+\begin{enumerate}
+\item{3 段目の手順。番号は小文字ローマ数字。}
+\end{enumerate}
+}
+\end{enumerate}
+}
+\end{enumerate}
+
+itemize と enumerate を混在させたネストでも、各種別のシーケンスに従うことを確認する。
+
+\begin{itemize}
+\item{外側は順序なしリスト（黒丸）。
+\begin{enumerate}
+\item{内側は順序付きリスト（小文字英字の丸括弧）。}
+\end{enumerate}
+}
+\end{itemize}
+
 箇条書きの後の段落です。


### PR DESCRIPTION
## 変更内容

`itemize` / `enumerate` をネストしたとき、深さに応じてマーカーの見た目が自動的に変わるようにした。

- **`crates/lowering/src/lib.rs`** — `LoweringContext` に `list_depth: usize`（0 = 最上位）を追加。`new` で 0 初期化、`with_body_font_kind` / `with_first_line_indent` に伝播、派生ヘルパ `with_list_depth` を追加。深さは `LoweringContext` に載せることで `lower_nodes` の signature を汚さず、item 内容の再帰 lower を経てネストへ伝播する。
- **`crates/lowering/src/list.rs`** — ネスト段用の固定シーケンスを const 化し、`lower_list` を深さ対応に:
  - unordered ネスト: `["–", "*", "·"]`（en dash → asterisk → middle dot）
  - ordered ネスト: `[(AlphaLower, "({number})"), (RomanLower, "{number}."), (AlphaUpper, "{number}.")]`
  - `depth == 0` は現行 `style.list`（`unordered_marker` / `ordered_marker_format`）を維持（非破壊）。`depth >= 1` は `(depth - 1) % 3` で系列を循環選択（5 段目 = 2 段目）。
  - ordered の番号描画は既存の `read_style::NumberStyle::render` を再利用。
  - item 内容は `with_list_depth(depth + 1)` で lower し、ネストしたリストへ深さ +1 を伝播。
- **`tests/text/itemize.sei`** — ネスト箇条書き（unordered 3 段・ordered 3 段・混在）の節を追加。

## 設計上の判断

- 段階別マーカーは固定シーケンスとし、`style.toml` には公開しない（issue のスコープ方針）。
- 深さは IR ではなく lowering の文脈（`LoweringContext`）に持たせた。IR にはネスト深さフィールドが無く、ネストは構造的再帰でのみ表現されるため、文脈に載せるのが最小変更。
- `\item[override]` 個別上書き（同 epic 配下の別 issue）は未実装。将来スロットできるよう、深さ別自動選択の直前を分岐ポイントとしてコメントで明示した。

## テスト

- `crates/lowering/src/list.rs`（ユニット）: unordered 3 段（`•/–/*`）・ordered 3 段（`1./(a)/i.`）・混在ネスト・5 段目の循環（`–` へ戻る）。単一段の既存テストは不変（回帰なし）。
- `crates/lowering/tests/smoke.rs`（結合）: `itemize.sei` を `parse_source → lower_nodes` に通し、レイアウト木を走査して深さ別マーカー（`•/–/*/1./(a)/i.`）が実際に生成されることを検証（パーサのネスト解釈込みの全パイプライン担保）。
- `cargo test -p lowering`（lib 125 + smoke 15）/ `cargo clippy` / `cargo +nightly fmt` すべて green。

## スコープ外

- マーカー段階配列の `style.toml` 公開
- ネストの字下げ量（インデント幅）の変更（既存実装で対応済み）
- `\item[override]` 個別マーカー上書き（別 issue）

Closes #154