### PR TITLE
組版: 縦アキ・改ページ制御を glue/penalty モデルへ移行

### DIFF
--- a/crates/hlist/src/block.rs
+++ b/crates/hlist/src/block.rs
@@ -11,6 +11,17 @@ use crate::{
   table_box::TableBox,
 };
 
+/// 強制改ページの分割コスト（−∞）。この penalty を持つ [`Block::Penalty`] は必ずそこで改ページする。
+///
+/// 水平リストの禁止規約（[`crate::hitem::HItem::Penalty`] は `i32::MAX` が禁止）と対称に、
+/// 縦方向では最小値を強制（必ず切る）、最大値を禁止（決して切らない）とする。
+pub const PENALTY_FORCE_BREAK: i32 = i32::MIN;
+
+/// 分割禁止の分割コスト（+∞）。この penalty を持つ [`Block::Penalty`] の直後では改ページしない。
+///
+/// keep-with-next（見出し直後の分割禁止・#168）が発行する想定で、本 issue（#166）では未発行。
+pub const PENALTY_FORBID_BREAK: i32 = i32::MAX;
+
 /// 文書の縦リスト要素
 #[derive(Debug, Clone)]
 pub enum Block {
@@ -102,15 +113,66 @@ pub enum Block {
     /// 本文幅の中での本体の水平揃え（既定は中央寄せ）
     align: Align,
   },
-  /// 縦方向の固定アキ（pt）
-  VSpace(f32),
-  /// 強制改ページ
-  PageBreak,
+  /// 縦方向の伸縮アキ（glue）
+  ///
+  /// `natural` は自然値（pt）、`stretch` / `shrink` は伸長 / 収縮能力（pt）。固定アキは
+  /// `stretch = 0.0, shrink = 0.0`（[`Block::fixed_space`]）。伸縮は下端揃え（#169）が解決する想定で、
+  /// 本 issue（#166）では常に 0 で `break_pages` は `natural` のみカーソルへ加算する。
+  Glue {
+    /// 自然値（pt）
+    natural: f32,
+    /// 伸長能力（pt）
+    stretch: f32,
+    /// 収縮能力（pt）
+    shrink: f32,
+  },
+  /// 分割コスト（penalty）
+  ///
+  /// `value` はそのブロック境界で改ページする際のコスト。[`PENALTY_FORCE_BREAK`]（−∞）は強制改ページ、
+  /// [`PENALTY_FORBID_BREAK`]（+∞）は分割禁止。有限値は「避けたいが可能」を表し、widow/orphan（#167）が
+  /// 発行する想定。本 issue（#166）が発行するのは強制改ページ（[`Block::force_break`]）のみ。
+  Penalty {
+    /// 分割コスト（小さいほど切りやすい。−∞=強制 / +∞=禁止）
+    value: i32,
+  },
   /// リンク行き先のアンカー（機構 A・ゼロサイズ）
   ///
   /// `break_pages` で次に配置される実ブロックの確定座標に解決され、`Page::anchors` に
   /// `PlacedAnchor` として格納される。それ自身は縦方向のアキを生まない。
   Anchor(AnchorMark),
+}
+
+impl Block {
+  /// 固定の縦アキ（伸縮なし）を作る。`natural = pt`, `stretch = shrink = 0`。
+  ///
+  /// 「固定アキ = 伸縮 0 の glue」という表現の真実源。既存の固定アキ生成箇所はすべてこれを使う。
+  #[must_use]
+  pub fn fixed_space(pt: f32) -> Block {
+    return Block::Glue {
+      natural: pt,
+      stretch: 0.0,
+      shrink: 0.0,
+    };
+  }
+
+  /// 強制改ページ（`Penalty { value: PENALTY_FORCE_BREAK }`）を作る。
+  #[must_use]
+  pub fn force_break() -> Block {
+    return Block::Penalty {
+      value: PENALTY_FORCE_BREAK,
+    };
+  }
+
+  /// 強制改ページの penalty かどうかを返す。
+  #[must_use]
+  pub fn is_force_break(&self) -> bool {
+    return matches!(
+      self,
+      Block::Penalty {
+        value: PENALTY_FORCE_BREAK
+      }
+    );
+  }
 }
 
 /// 数式ブロックの行番号（測定済み）

--- a/crates/hlist/src/break_pages.rs
+++ b/crates/hlist/src/break_pages.rs
@@ -14,7 +14,7 @@ use tracing::debug;
 use types::{AnchorMark, TextAlignment};
 
 use crate::{
-  block::Block,
+  block::{Block, PENALTY_FORBID_BREAK, PENALTY_FORCE_BREAK},
   break_lines::LineBreaker,
   line::Line,
   page::{Page, PlacedAnchor, PlacedBlock, PlacedLink, PlacedMathNumber, PlacedTableRow},
@@ -79,6 +79,12 @@ struct PageComposer {
   column_gap: f32,
   /// 現在の段インデックス（0 = 左段）。`column_offset` の算出に使う
   col: usize,
+  /// 直前の [`Block::Penalty`] から引き継いだ分割コスト（次の内容ブロックの改ページ判定で参照）
+  ///
+  /// 内容ブロックを配置するたびに [`PageComposer::take_pending_penalty`] で読み取ってリセットする。
+  /// 既定 0（中立）。強制改ページ（−∞）は eager に処理するためここには積まない。本 issue（#166）では
+  /// 発行者がいないため常に 0 で、[`PageComposer::consider_break`] は幾何判定のみに帰着する。
+  pending_penalty: i32,
 }
 
 impl PageComposer {
@@ -95,6 +101,7 @@ impl PageComposer {
       column_width,
       column_gap: geom.column_gap,
       col: 0,
+      pending_penalty: 0,
     };
   }
 
@@ -118,6 +125,30 @@ impl PageComposer {
       self.cursor_at_edge = false;
     } else {
       self.start_new_page(geom);
+    }
+  }
+
+  /// 直前の [`Block::Penalty`] から引き継いだ分割コストを読み取ってリセットする。
+  fn take_pending_penalty(&mut self) -> i32 { return std::mem::replace(&mut self.pending_penalty, 0); }
+
+  /// ブロック配置前の改ページ判定（分割コスト参照の一本化ポイント）。
+  ///
+  /// `next_height` は次に置く内容ブロックの高さ、`penalty` は直前の境界の分割コスト
+  /// （[`PageComposer::take_pending_penalty`] の戻り値）。判定は次の一本:
+  ///
+  /// - [`PENALTY_FORBID_BREAK`]（+∞）: 分割禁止。オーバーフローしても切らない（keep-with-next・#168 が発行）。
+  /// - それ以外: 高さがページ下限を超えるなら [`PageComposer::advance_region`] で改段 / 改ページする（幾何判定）。
+  ///
+  /// 強制改ページ（[`PENALTY_FORCE_BREAK`]）はここを通さず [`break_pages`] の match アームで eager に処理する
+  /// （直前のアキが旧ページ末尾に乗るのを避けるため）。本 issue（#166）では有限 / 禁止 penalty の発行者が
+  /// いないため常に `penalty == 0` で、実質は幾何判定のみ。有限 penalty を使う widow/orphan（#167）は
+  /// ここに badness 判定を足す。
+  fn consider_break(&mut self, next_height: f32, penalty: i32, geom: &PageGeometry) {
+    if penalty == PENALTY_FORBID_BREAK {
+      return;
+    }
+    if self.y + next_height > geom.page_limit {
+      self.advance_region(geom);
     }
   }
 
@@ -246,20 +277,26 @@ pub fn break_pages(
       Block::ComposedLine { line, leading } => {
         place_single_line(&mut composer, geom, line, leading);
       },
-      Block::VSpace(space) => {
-        composer.y += space;
+      // 伸縮アキ。本 issue（#166）では stretch / shrink を消費せず自然値のみカーソルへ加算する
+      // （VSpace と同一挙動）。cursor_at_edge は触らない（アキはフラグを変えない）。
+      Block::Glue { natural, .. } => {
+        composer.y += natural;
       },
-      Block::PageBreak => {
-        composer.start_new_page(geom);
+      // 分割コスト。強制改ページ（−∞）は eager に改ページ。有限 / 禁止は次の内容ブロックへ持ち越す。
+      Block::Penalty { value } => {
+        if value == PENALTY_FORCE_BREAK {
+          composer.start_new_page(geom);
+        } else {
+          composer.pending_penalty = value;
+        }
       },
       Block::Rule {
         width,
         height,
         align,
       } => {
-        if composer.y + height > geom.page_limit {
-          composer.advance_region(geom);
-        }
+        let penalty = composer.take_pending_penalty();
+        composer.consider_break(height, penalty, geom);
         // 改段・改ページ後の段オフセットを読む（着地段に合わせる）
         let col_off = composer.column_offset();
         composer.resolve_pending_anchors(col_off, composer.y);
@@ -283,9 +320,8 @@ pub fn break_pages(
         // 縦組版は確定済みサイズを前提とする（resolve_images prepass 後）。未解決は 0 扱い
         let width = width.unwrap_or(0.0);
         let height = height.unwrap_or(0.0);
-        if composer.y + height > geom.page_limit {
-          composer.advance_region(geom);
-        }
+        let penalty = composer.take_pending_penalty();
+        composer.consider_break(height, penalty, geom);
         // 改段・改ページ後の段オフセットを読む（着地段に合わせる）
         let col_off = composer.column_offset();
         composer.resolve_pending_anchors(col_off, composer.y);
@@ -727,11 +763,11 @@ mod tests {
 
   #[test]
   fn vspace_shifts_following_baseline() {
-    // VSpace は次のブロックのベースラインを下へずらす
+    // 固定アキ（glue）は次のブロックのベースラインを下へずらす
     let geom = test_geometry();
     let blocks = vec![
       paragraph_of_lines(1),
-      Block::VSpace(5.0),
+      Block::fixed_space(5.0),
       paragraph_of_lines(1),
     ];
 
@@ -754,7 +790,7 @@ mod tests {
     let geom = test_geometry();
     let blocks = vec![
       paragraph_of_lines(1),
-      Block::PageBreak,
+      Block::force_break(),
       paragraph_of_lines(1),
     ];
 
@@ -871,9 +907,9 @@ mod tests {
     let geom = test_geometry();
     let blocks = vec![
       paragraph_of_lines(1),
-      Block::PageBreak,
+      Block::force_break(),
       paragraph_of_lines(1),
-      Block::PageBreak,
+      Block::force_break(),
       paragraph_of_lines(1),
     ];
 
@@ -886,7 +922,7 @@ mod tests {
   fn leading_page_break_does_not_create_blank_page() {
     // 先頭が改ページ（Part 見出しの page_break_before 相当）でも、白紙の先頭ページを作らない
     let geom = test_geometry();
-    let blocks = vec![Block::PageBreak, paragraph_of_lines(1)];
+    let blocks = vec![Block::force_break(), paragraph_of_lines(1)];
 
     let pages = break_pages(blocks, 100.0, &geom, &GreedyBreaker, TextAlignment::RaggedRight);
 
@@ -901,8 +937,8 @@ mod tests {
     let geom = test_geometry();
     let blocks = vec![
       paragraph_of_lines(1),
-      Block::PageBreak,
-      Block::PageBreak,
+      Block::force_break(),
+      Block::force_break(),
       paragraph_of_lines(1),
     ];
 

--- a/crates/hlist/src/lib.rs
+++ b/crates/hlist/src/lib.rs
@@ -39,7 +39,7 @@ pub mod line;
 pub mod page;
 pub mod table_box;
 
-pub use block::{Block, MathRowNumber};
+pub use block::{Block, MathRowNumber, PENALTY_FORBID_BREAK, PENALTY_FORCE_BREAK};
 pub use break_lines::{GreedyBreaker, KnuthPlassBreaker, LineBreaker};
 pub use break_opportunities::{BreakKind, BreakPoint, break_opportunities};
 pub use break_pages::{PageGeometry, break_pages, column_width};

--- a/crates/layout/src/lib.rs
+++ b/crates/layout/src/lib.rs
@@ -197,11 +197,11 @@ impl Measurer<'_> {
           let child_right_indent = right_indent + vbox_right_indent.to_pt();
           self.walk_vertical(children, blocks, paragraph, child_indent, child_right_indent, vbox_align);
           self.flush_paragraph(blocks, paragraph, child_indent, child_right_indent, vbox_align);
-          blocks.push(Block::VSpace(margin_bottom.to_pt()));
+          blocks.push(Block::fixed_space(margin_bottom.to_pt()));
         },
         LayoutNode::Vkern { length } => {
           self.flush_paragraph(blocks, paragraph, indent, right_indent, align);
-          blocks.push(Block::VSpace(length.to_pt()));
+          blocks.push(Block::fixed_space(length.to_pt()));
         },
         LayoutNode::Rule { width, height } => {
           self.flush_paragraph(blocks, paragraph, indent, right_indent, align);
@@ -249,7 +249,7 @@ impl Measurer<'_> {
         },
         LayoutNode::PageBreak => {
           self.flush_paragraph(blocks, paragraph, indent, right_indent, align);
-          blocks.push(Block::PageBreak);
+          blocks.push(Block::force_break());
         },
       }
     }

--- a/crates/layout/src/toc.rs
+++ b/crates/layout/src/toc.rs
@@ -81,7 +81,7 @@ pub fn build_toc_blocks(
     leading: spec.title_style.font_size * spec.line_height_factor,
   });
   if spec.title_bottom_margin > 0.0 {
-    blocks.push(Block::VSpace(spec.title_bottom_margin));
+    blocks.push(Block::fixed_space(spec.title_bottom_margin));
   }
 
   // エントリ行
@@ -94,7 +94,7 @@ pub fn build_toc_blocks(
   }
 
   if spec.bottom_margin > 0.0 {
-    blocks.push(Block::VSpace(spec.bottom_margin));
+    blocks.push(Block::fixed_space(spec.bottom_margin));
   }
   return blocks;
 }

--- a/crates/seiran/src/build_pdf/front_matter.rs
+++ b/crates/seiran/src/build_pdf/front_matter.rs
@@ -50,7 +50,7 @@ pub(super) fn assemble_front_matter(
     let toc_blocks = build_toc_blocks(&toc_spec, &toc_entries, shapers, metrics);
     if !toc_blocks.is_empty() {
       front_blocks.extend(toc_blocks);
-      front_blocks.push(Block::PageBreak);
+      front_blocks.push(Block::force_break());
       debug!(toc_entry_count = toc_entries.len(), "目次を生成しました");
     }
   }
@@ -115,8 +115,8 @@ fn build_toc_spec(style: &Style, text_width: f32) -> TocSpec {
 /// 前付け（タイトルページ → 目次）ブロックを単独でページ分割する。
 ///
 /// 前付けは常に単段（`front_geometry`）。本文ページ列と連結する前提なので、本文との区切り用に末尾へ
-/// 付いている `Block::PageBreak` は落とす（[`hlist::break_pages`] の `finish` が末尾ページを無条件に
-/// push するため、残すと空の末尾ページが生じる）。タイトル → 目次間の中間 `PageBreak` は保持する。
+/// 付いている強制改ページ（[`Block::force_break`]）は落とす（[`hlist::break_pages`] の `finish` が末尾
+/// ページを無条件に push するため、残すと空の末尾ページが生じる）。タイトル → 目次間の中間の強制改ページは保持する。
 /// 前付けが空（タイトルページ・目次ともに無効）のときは空ページを作らず空の列を返す。
 pub(super) fn break_front_matter(
   mut front_blocks: Vec<Block>,
@@ -125,7 +125,7 @@ pub(super) fn break_front_matter(
   breaker: &dyn LineBreaker,
   alignment: TextAlignment,
 ) -> Vec<Page> {
-  if matches!(front_blocks.last(), Some(Block::PageBreak)) {
+  if front_blocks.last().is_some_and(Block::is_force_break) {
     front_blocks.pop();
   }
   if front_blocks.is_empty() {


### PR DESCRIPTION
## 変更内容

縦リストのアキと改ページ制御を、水平リスト（`HItem`）と同型の glue/penalty モデルへ移行する**挙動不変リファクタ**。epic #165 の先頭タスク。

- `Block::VSpace(f32)` → `Block::Glue { natural, stretch, shrink }`（`crates/hlist/src/block.rs`）。固定アキ = 伸縮 0 の glue（`Block::fixed_space`）。`stretch`/`shrink` は #169（下端揃え）の下地としてフィールドだけ導入し、本 PR では常に 0・未消費。
- `Block::PageBreak` → `Block::Penalty { value: i32 }`。強制改ページ = `PENALTY_FORCE_BREAK`（−∞、`Block::force_break`）、分割禁止 = `PENALTY_FORBID_BREAK`（+∞、#168 用に定数のみ）。末尾判定用に `Block::is_force_break`。
- `break_pages` に単一チョークポイント `consider_break(next_height, penalty, geom)` を追加し、Rule/Image のブロック単位プリブレイク判定を集約。penalty は直前の `Block::Penalty` から `pending_penalty` 経由で引き継ぐ。
- 上流構築サイト（`layout::build_blocks`・TOC・`front_matter`）を新 API へ差し替え。

## 設計上の判断

- **強制改ページは eager 維持**: 旧 `PageBreak` は即 `start_new_page`。遅延させると直後のアキ（`margin_bottom` 等の glue）が旧ページ末尾に乗り座標が変わるため、`Penalty{FORCE}` は match アームで即処理し `consider_break` を経由させない。
- **glue を破棄しない / `cursor_at_edge` を触らない**: 現行 `VSpace` の挙動（ページ先頭でも無条件加算・フラグ不変）をそのまま踏襲。
- **数式ブロック・非分割表のプリブレイクは funnel に巻き込まない**: これらは「新しい段に収まる場合のみ改段」という別の述語（不可分アトム機構）なので現状維持。段落内の行単位分割も対象外。
- **上流 IR は離散ノードのまま**: glue/penalty 概念は hlist の Block 層に閉じ、`LayoutNode`/`DocNode` の `PageBreak` は build_blocks 境界で `Block::force_break()` に落とす。

## テスト

- `cargo test --workspace` 全緑。`cargo +nightly fmt` / `cargo clippy` クリーン。
- **挙動不変の主判定**: レイアウトスナップショット golden（#172）`layout_dumps_match_golden` が `crates/seiran/tests/golden/*.txt` に**差分ゼロ**で通過（`git diff --stat` 空）＝座標レベル等価。

## スコープ外

- 有限 penalty の発行と widow/orphan（#167）、keep-with-next の +∞ 発行（#168）、伸縮解決＝下端揃え（#169）。
- 数式ブロック・非分割表の不可分機構の penalty 再表現。上流 `LayoutNode`/`DocNode` の glue/penalty 化。

## 関連

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)