### PR TITLE
組版: 下端揃え (flush bottom) オプション

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,6 +239,7 @@ pub enum MyError {
 - **見出し（2 レイヤーマージ）**: `default_for_level()` (Rust) → `[heading.<level>]`（レベル別差分）の順に重畳。`[heading]` 直下にスカラーは書けない（テーブル形式のみ）
 - **カウンタ（`CounterStyle`）**: `[counters.<name>]` の `<name>` は固定 9 種（`part` / `chapter` / `section` / `subsection` / `paragraph` / `subparagraph` / `table` / `figure` / `equation`）のみ。各エントリは `display_name` / `number_format` / `number_style` / `ref_format` / `resets` を持ち、未知のカウンタ名は `deny_unknown_fields` で拒否
 - **数式（`MathStyle`）**: `[math.script]`（`MathScriptStyle`＝上付き / 下付きの倍率・シフト等。インライン数式 `$...$` にも効く。将来 OpenType MATH テーブルから自動取得する想定で現状は手動指定）と `[math.block]`（`MathBlockStyle`＝表示数式ブロックのレイアウト。`tag_format` / `number_side` / `alignment` / `row_gap` / `column_gap` / `top_margin` / `bottom_margin`。全表示数式環境 equation / align / gather / split / multiline / cases / matrix が共有）の 2 副テーブルを束ねる。旧 `[equation]` テーブルは廃止（`[math.block]` に統合）
+- **ページ組版（`PageStyle`）**: `[page]` に組版挙動フラグを集約（段組みは別テーブル `[columns]`）。`flush_bottom`（既定 `false`）は下端揃え＝満杯ページ / 段の不足高さを段落間・見出し前後等の伸縮アキ（`Block::Glue` の stretch）へ比例配分し最終ベースラインを版面下端へ揃える。最終ページ・強制改ページ直前・伸縮アキの無いページは自然高のまま。無効時の出力は従来と同一（`break_pages` は stretch を無視する）
 
 19 フォント種別: `serif`, `serif_bold`, `serif_italic`, `serif_bold_italic`, `sans_serif`, `sans_serif_bold`, `sans_serif_italic`, `sans_serif_bold_italic`, `monospace`, `monospace_bold`, `monospace_italic`, `monospace_bold_italic`, `math`, `japanese_serif`, `japanese_serif_bold`, `japanese_sans_serif`, `japanese_sans_serif_bold`, `japanese_monospace`, `japanese_monospace_bold`
 

--- a/crates/hlist/src/block.rs
+++ b/crates/hlist/src/block.rs
@@ -118,8 +118,10 @@ pub enum Block {
   /// 縦方向の伸縮アキ（glue）
   ///
   /// `natural` は自然値（pt）、`stretch` / `shrink` は伸長 / 収縮能力（pt）。固定アキは
-  /// `stretch = 0.0, shrink = 0.0`（[`Block::fixed_space`]）。伸縮は下端揃え（#169）が解決する想定で、
-  /// 本 issue（#166）では常に 0 で `break_pages` は `natural` のみカーソルへ加算する。
+  /// `stretch = 0.0, shrink = 0.0`（[`Block::fixed_space`]）。ブロック間アキは自然値に比例した
+  /// `stretch` を持ち（[`Block::stretchable_space`]）、下端揃え（#169）が満杯リージョンの不足高さを
+  /// この `stretch` へ比例配分する。下端揃えが無効なら `break_pages` は `stretch` を無視して `natural`
+  /// のみカーソルへ加算するため出力は不変。
   Glue {
     /// 自然値（pt）
     natural: f32,
@@ -153,6 +155,20 @@ impl Block {
     return Block::Glue {
       natural: pt,
       stretch: 0.0,
+      shrink: 0.0,
+    };
+  }
+
+  /// 伸縮する縦アキ（glue）を作る。`natural = pt`, `stretch = stretch`, `shrink = 0`。
+  ///
+  /// ブロック間アキ（段落間・見出し前後等）に使う。下端揃え（#169）が満杯リージョンの不足高さを
+  /// `stretch` へ比例配分し、最終ベースラインを版面下端へ寄せる。収縮は持たない（リージョンは
+  /// オーバーフロー前に分割するため不足高さは常に 0 以上で、詰める必要がない）。
+  #[must_use]
+  pub fn stretchable_space(pt: f32, stretch: f32) -> Block {
+    return Block::Glue {
+      natural: pt,
+      stretch,
       shrink: 0.0,
     };
   }

--- a/crates/hlist/src/break_pages.rs
+++ b/crates/hlist/src/break_pages.rs
@@ -41,6 +41,13 @@ pub struct PageGeometry {
   pub num_columns: usize,
   /// 段間（gutter、pt）。隣り合う段の間隔
   pub column_gap: f32,
+  /// 下端揃え（flush bottom）を有効にするか（`style.toml` の `[page] flush_bottom`）。
+  ///
+  /// `true` のとき、満杯になった段（リージョン）の不足高さを段内の伸縮アキ（glue の stretch）へ
+  /// 比例配分し、最終ベースラインを版面下端（`page_limit`）へ寄せる。最終ページ・強制改ページ直前の
+  /// リージョン・伸縮アキが無いリージョンは揃えない（自然高のまま）。前付け（`front_geometry`）は常に
+  /// `false`。既定 `false` で従来どおりの ragged bottom。
+  pub flush_bottom: bool,
 }
 
 /// 本文幅 `text_width` を `num_columns` 段に分けたときの 1 段あたりの幅（pt）を返す。
@@ -85,6 +92,31 @@ struct PageComposer {
   /// 既定 0（中立）。強制改ページ（−∞）は eager に処理するためここには積まない。本 issue（#166）では
   /// 発行者がいないため常に 0 で、[`PageComposer::consider_break`] は幾何判定のみに帰着する。
   pending_penalty: i32,
+  /// 現在リージョン（段）の先頭 index（`current` 内）。下端揃え（#169）がここから末尾までを揃える。
+  region_start: usize,
+  /// 現在リージョンの先頭 index（`current_links` 内）。下端揃えでリンク矩形を本体と同量シフトする。
+  region_link_start: usize,
+  /// 現在リージョンの先頭 index（`current_anchors` 内）。下端揃えでアンカーを本体と同量シフトする。
+  region_anchor_start: usize,
+  /// 現在リージョンの伸縮アキ（下端揃え用）。各アキ通過時点の `current` / `current_links` /
+  /// `current_anchors` の要素数（＝そのアキより後に来る要素の開始 index）と stretch を記録し、
+  /// [`PageComposer::end_region`] が不足高さを配置順ベースで比例配分する。
+  region_glues: Vec<GlueMark>,
+}
+
+/// 下端揃え（#169）用の伸縮アキ記録
+///
+/// アキを消費した時点の各配置ベクタの長さを覚えておくことで、座標比較に頼らずに「このアキより後に
+/// 置かれた要素」を index で厳密に判定する（行の箱がアキ帯へ食い込む等の座標曖昧性を回避する）。
+struct GlueMark {
+  /// 伸長能力（pt）。配分の重み
+  stretch: f32,
+  /// このアキ記録時点の `current` の要素数（このアキより後のブロックはこの index 以降）
+  block_at: usize,
+  /// このアキ記録時点の `current_links` の要素数
+  link_at: usize,
+  /// このアキ記録時点の `current_anchors` の要素数
+  anchor_at: usize,
 }
 
 impl PageComposer {
@@ -102,6 +134,10 @@ impl PageComposer {
       column_gap: geom.column_gap,
       col: 0,
       pending_penalty: 0,
+      region_start: 0,
+      region_link_start: 0,
+      region_anchor_start: 0,
+      region_glues: Vec::new(),
     };
   }
 
@@ -119,6 +155,10 @@ impl PageComposer {
   /// （次段の先頭は段落先頭行と同じ扱いにするため `cursor_at_edge` も倒す）。最終段で
   /// 超えたときだけ [`PageComposer::start_new_page`] へフォールスルーして実際に改ページする。
   fn advance_region(&mut self, geom: &PageGeometry) {
+    // 満杯になったリージョン（段）を先に確定する。下端揃え（#169）が有効なら不足高さを段内の
+    // 伸縮アキへ配分してから次段 / 次ページへ移る。強制改ページ・最終ページはこの経路を通らない
+    // （それぞれ match アームの `start_new_page` 直接呼び・`finish` が確定）ため揃えられない。
+    self.end_region(geom, true);
     if self.col + 1 < self.num_columns {
       self.col += 1;
       self.y = geom.margin_top;
@@ -184,6 +224,12 @@ impl PageComposer {
     self.y = geom.margin_top;
     self.cursor_at_edge = false;
     self.col = 0;
+    // ページ確定で `current` / `current_links` / `current_anchors` を空にしたので、次ページ先頭段の
+    // リージョン追跡を 0 から開始する。伸縮アキも新ページに持ち越さない。
+    self.region_start = 0;
+    self.region_link_start = 0;
+    self.region_anchor_start = 0;
+    self.region_glues.clear();
   }
 
   /// 未解決アンカーを確定座標 `(x, y)` で現在ページに解決する
@@ -228,6 +274,97 @@ impl PageComposer {
       links: self.current_links,
     });
     return self.pages;
+  }
+
+  /// 現在リージョン（段）を確定し、下端揃え（#169）が有効なら不足高さを段内の伸縮アキへ配分する。
+  ///
+  /// `flush` は「このリージョンを揃える対象にするか」。満杯で改段・改ページする経路（[`advance_region`]）
+  /// だけが `true` を渡す。強制改ページ直前・最終ページはこのメソッドを通さない（=揃えない）。配分は
+  /// 配置順ベース: 各ブロック（およびリンク矩形・アンカー）を「それより前に記録された伸縮アキの
+  /// stretch 合計 × ratio」だけ下方へずらす。末尾ブロックが不足高さ全量だけ下がり、リージョン下端が
+  /// 版面下限（`page_limit`）に達する。リージョン末尾のアキ（末尾ブロックより後に記録された分＝改段で
+  /// 捨てられるアキ）は配分の分母から除く（除かないと下端が不足高さ分だけ届かなくなる）。
+  ///
+  /// いずれの場合も次リージョンのためにリージョン追跡（`region_*`）を現在の末尾へリセットする。
+  fn end_region(&mut self, geom: &PageGeometry, flush: bool) {
+    let glues = std::mem::take(&mut self.region_glues);
+    let region_start = self.region_start;
+    let link_start = self.region_link_start;
+    let anchor_start = self.region_anchor_start;
+    let has_blocks = region_start < self.current.len();
+    if flush && geom.flush_bottom && has_blocks && !glues.is_empty() {
+      let last_index = self.current.len() - 1;
+      // リージョン下端 = 段内ブロックの底辺の最大値（末尾ブロックが最下）。
+      let region_bottom = self.current[region_start..].iter().map(placed_block_bottom).fold(f32::MIN, f32::max);
+      let deficit = geom.page_limit - region_bottom;
+      // 分母 = 末尾ブロックより前に記録されたアキの stretch 合計（末尾アキは除く）。
+      let effective: f32 = glues.iter().filter(|g| g.block_at <= last_index).map(|g| g.stretch).sum();
+      // 不足高さ・分母が正のときだけ配分する（負・ゼロは揃えても意味がないので自然高のまま）。
+      if deficit > FLUSH_EPSILON && effective > 0.0 {
+        let ratio = deficit / effective;
+        for (offset, block) in self.current[region_start..].iter_mut().enumerate() {
+          let idx = region_start + offset;
+          let stretch: f32 = glues.iter().filter(|g| g.block_at <= idx).map(|g| g.stretch).sum();
+          shift_placed_block(block, ratio * stretch);
+        }
+        for (offset, link) in self.current_links[link_start..].iter_mut().enumerate() {
+          let idx = link_start + offset;
+          let stretch: f32 = glues.iter().filter(|g| g.link_at <= idx).map(|g| g.stretch).sum();
+          link.y += ratio * stretch;
+        }
+        for (offset, anchor) in self.current_anchors[anchor_start..].iter_mut().enumerate() {
+          let idx = anchor_start + offset;
+          let stretch: f32 = glues.iter().filter(|g| g.anchor_at <= idx).map(|g| g.stretch).sum();
+          anchor.y += ratio * stretch;
+        }
+      }
+    }
+    self.region_start = self.current.len();
+    self.region_link_start = self.current_links.len();
+    self.region_anchor_start = self.current_anchors.len();
+  }
+}
+
+/// 下端揃え（#169）で配分を行う不足高さの下限（pt）。これ未満は浮動小数の誤差とみなし揃えない。
+const FLUSH_EPSILON: f32 = 1e-3;
+
+/// [`PlacedBlock`] の底辺（ページ上端からの距離、pt）を返す。下端揃えのリージョン下端算出に使う。
+fn placed_block_bottom(block: &PlacedBlock) -> f32 {
+  return match block {
+    PlacedBlock::Line { line, baseline_y } => baseline_y + line.depth,
+    PlacedBlock::MathBlock {
+      body, baseline_y, ..
+    } => baseline_y + body.depth,
+    PlacedBlock::Image { y, height, .. } | PlacedBlock::Rule { y, height, .. } => y + height,
+    PlacedBlock::Table { rows, .. } => rows.last().map_or(f32::MIN, |r| r.top_y + r.height),
+  };
+}
+
+/// [`PlacedBlock`] とその内部の確定座標を下方へ `dy` だけずらす（下端揃えの配分で使う）。
+///
+/// 数式ブロックは本体ベースラインと各行番号を、表は全行の上端を一律にずらす。水平座標は変えない。
+fn shift_placed_block(block: &mut PlacedBlock, dy: f32) {
+  if dy == 0.0 {
+    return;
+  }
+  match block {
+    PlacedBlock::Line { baseline_y, .. } => *baseline_y += dy,
+    PlacedBlock::MathBlock {
+      baseline_y,
+      numbers,
+      ..
+    } => {
+      *baseline_y += dy;
+      for number in numbers {
+        number.baseline_y += dy;
+      }
+    },
+    PlacedBlock::Image { y, .. } | PlacedBlock::Rule { y, .. } => *y += dy,
+    PlacedBlock::Table { rows, .. } => {
+      for row in rows {
+        row.top_y += dy;
+      }
+    },
   }
 }
 
@@ -310,9 +447,20 @@ pub fn break_pages(
       Block::ComposedLine { line, leading } => {
         place_single_line(&mut composer, geom, line, leading);
       },
-      // 伸縮アキ。本 issue（#166）では stretch / shrink を消費せず自然値のみカーソルへ加算する
-      // （VSpace と同一挙動）。cursor_at_edge は触らない（アキはフラグを変えない）。
-      Block::Glue { natural, .. } => {
+      // 伸縮アキ。カーソルへは自然値のみ加算する（下端揃え無効時は VSpace と同一挙動）。stretch を持つ
+      // アキは下端揃え（#169）用に配置順（各配置ベクタの現在長）と stretch を記録しておき、リージョン確定時に
+      // 不足高さを配分する。cursor_at_edge は触らない（アキはフラグを変えない）。
+      Block::Glue {
+        natural, stretch, ..
+      } => {
+        if stretch != 0.0 {
+          composer.region_glues.push(GlueMark {
+            stretch,
+            block_at: composer.current.len(),
+            link_at: composer.current_links.len(),
+            anchor_at: composer.current_anchors.len(),
+          });
+        }
         composer.y += natural;
       },
       // 分割コスト。強制改ページ（−∞）は eager に改ページ。有限は次の内容ブロックへ持ち越す。
@@ -1012,6 +1160,7 @@ mod tests {
       table_cell_padding: 2.0,
       num_columns: 1,
       column_gap: 0.0,
+      flush_bottom: false,
     };
   }
 
@@ -2526,5 +2675,175 @@ mod tests {
 
     // Assert — 見出しは 1 ページ目先頭（回避不能で孤立を許容）、本文は 2 ページ目。空ページは生じない
     assert_eq!(line_counts(&pages), vec![1, 2], "{pages:?}");
+  }
+
+  // ---- 下端揃え（flush bottom・#169）--------------------------------------------------------------
+
+  /// 下端揃えを有効にしたテスト用ジオメトリ（他は `test_geometry` と同じ）
+  fn flush_geometry() -> PageGeometry {
+    return PageGeometry {
+      flush_bottom: true,
+      ..test_geometry()
+    };
+  }
+
+  /// 高さ `height` の罫線ブロック（幅 10・左揃え）
+  fn rule(height: f32) -> Block {
+    return Block::Rule {
+      width: 10.0,
+      height,
+      align: types::Align::Left,
+    };
+  }
+
+  /// ページ内の罫線の上端 y を上から順に集める
+  fn rule_ys(page: &Page) -> Vec<f32> {
+    return page
+      .blocks
+      .iter()
+      .filter_map(|b| match b {
+        PlacedBlock::Rule { y, .. } => Some(*y),
+        _ => None,
+      })
+      .collect();
+  }
+
+  /// ページ内ブロックの底辺の最大値（版面下端に達したかの確認用）
+  fn max_block_bottom(page: &Page) -> f32 {
+    return page.blocks.iter().map(super::placed_block_bottom).fold(f32::MIN, f32::max);
+  }
+
+  /// 2 つの `f32` がほぼ等しいか（配置座標の比較用）
+  fn approx(a: f32, b: f32) -> bool { return (a - b).abs() < 1e-3; }
+
+  #[test]
+  fn flush_bottom_distributes_deficit_into_stretch_glue() {
+    // Arrange — 罫線 3 本を伸縮アキ 2 個で挟み、4 本目でページを溢れさせる。1 ページ目は満杯（不足 2pt）
+    // なので下端揃えの対象になる。伸縮アキは等量なので不足高さは 1pt ずつ配分される。
+    let geom = flush_geometry();
+    let blocks = vec![
+      rule(10.0),                         // y=10..20
+      Block::stretchable_space(4.0, 4.0), // 24
+      rule(10.0),                         // y=24..34
+      Block::stretchable_space(4.0, 4.0), // 38
+      rule(10.0),                         // y=38..48（不足 2pt）
+      rule(10.0),                         // 溢れて改ページ（1 ページ目を確定＝下端揃え発火）
+    ];
+
+    // Act
+    let pages = break_pages(blocks, 100.0, &geom, &GreedyBreaker, TextAlignment::RaggedRight);
+
+    // Assert — 1 ページ目は各アキが 1pt ずつ伸び、末尾罫線の底辺が版面下限 50 に達する
+    assert_eq!(pages.len(), 2);
+    assert_eq!(rule_ys(&pages[0]), vec![10.0, 25.0, 40.0]);
+    assert!(approx(max_block_bottom(&pages[0]), 50.0), "{:?}", pages[0]);
+    // 最終ページは自然高のまま（揃えない）
+    assert_eq!(rule_ys(&pages[1]), vec![10.0]);
+  }
+
+  #[test]
+  fn flush_bottom_disabled_keeps_ragged_bottom() {
+    // Arrange — 下端揃え無効。同じ入力でも従来どおり自然高で終わる
+    let geom = test_geometry();
+    let blocks = vec![
+      rule(10.0),
+      Block::stretchable_space(4.0, 4.0),
+      rule(10.0),
+      Block::stretchable_space(4.0, 4.0),
+      rule(10.0),
+      rule(10.0),
+    ];
+
+    // Act
+    let pages = break_pages(blocks, 100.0, &geom, &GreedyBreaker, TextAlignment::RaggedRight);
+
+    // Assert — アキは自然値のまま、末尾は 48（<50）
+    assert_eq!(rule_ys(&pages[0]), vec![10.0, 24.0, 38.0]);
+    assert!(approx(max_block_bottom(&pages[0]), 48.0));
+  }
+
+  #[test]
+  fn flush_bottom_shifts_paragraph_lines() {
+    // Arrange — 段落（Line）3 個を伸縮アキで挟み、大きな罫線で溢れさせる。行の底辺（baseline+depth）で
+    // リージョン下端を測り、行を丸ごと下方シフトすることを確認する。
+    let geom = flush_geometry();
+    let blocks = vec![
+      paragraph_of_lines(1),              // baseline 10（bottom 12）、以後カーソルは +leading(12)
+      Block::stretchable_space(4.0, 4.0), // ba=1
+      paragraph_of_lines(1),              // baseline 26
+      Block::stretchable_space(4.0, 4.0), // ba=2
+      paragraph_of_lines(1),              // baseline 42（bottom 44・不足 6pt）
+      rule(30.0),                         // 溢れて改ページ
+    ];
+
+    // Act
+    let pages = break_pages(blocks, 100.0, &geom, &GreedyBreaker, TextAlignment::RaggedRight);
+
+    // Assert — 不足 6pt を等量アキへ 3:3 で配分（0.75 × 4 = 3pt ずつ累積）。末尾行の底辺が 50 に達する
+    assert_eq!(page_baselines(&pages[0]), vec![10.0, 29.0, 48.0]);
+    assert!(approx(max_block_bottom(&pages[0]), 50.0), "{:?}", pages[0]);
+  }
+
+  #[test]
+  fn flush_bottom_aligns_last_baseline_across_pages() {
+    // Arrange — 罫線 7 本を伸縮アキで連ね、2 ページを満杯にして 3 ページ目に 1 本残す
+    let geom = flush_geometry();
+    let mut blocks = Vec::new();
+    for i in 0..7 {
+      if i > 0 {
+        blocks.push(Block::stretchable_space(4.0, 4.0));
+      }
+      blocks.push(rule(10.0));
+    }
+
+    // Act
+    let pages = break_pages(blocks, 100.0, &geom, &GreedyBreaker, TextAlignment::RaggedRight);
+
+    // Assert — 満杯の 1・2 ページ目は下端が版面下限で揃い、最終ページだけ自然高
+    assert_eq!(pages.len(), 3);
+    assert!(approx(max_block_bottom(&pages[0]), 50.0), "page0 {:?}", pages[0]);
+    assert!(approx(max_block_bottom(&pages[1]), 50.0), "page1 {:?}", pages[1]);
+    assert!(max_block_bottom(&pages[2]) < 50.0 - 1e-3, "last page ragged {:?}", pages[2]);
+  }
+
+  #[test]
+  fn flush_bottom_skips_page_before_forced_break() {
+    // Arrange — 強制改ページ直前のページは揃えない（自然高のまま）
+    let geom = flush_geometry();
+    let blocks = vec![
+      rule(10.0),
+      Block::stretchable_space(4.0, 4.0),
+      rule(10.0),
+      Block::force_break(), // このページは強制改ページで終わる → 揃えない
+      rule(10.0),
+    ];
+
+    // Act
+    let pages = break_pages(blocks, 100.0, &geom, &GreedyBreaker, TextAlignment::RaggedRight);
+
+    // Assert — 1 ページ目は自然高（10, 24）のまま
+    assert_eq!(pages.len(), 2);
+    assert_eq!(rule_ys(&pages[0]), vec![10.0, 24.0]);
+    assert_eq!(rule_ys(&pages[1]), vec![10.0]);
+  }
+
+  #[test]
+  fn flush_bottom_skips_page_without_stretch() {
+    // Arrange — 固定アキ（stretch=0）だけのページは配分先が無いので揃えない
+    let geom = flush_geometry();
+    let blocks = vec![
+      rule(10.0),
+      Block::fixed_space(4.0),
+      rule(10.0),
+      Block::fixed_space(4.0),
+      rule(10.0),
+      rule(10.0), // 溢れて改ページ
+    ];
+
+    // Act
+    let pages = break_pages(blocks, 100.0, &geom, &GreedyBreaker, TextAlignment::RaggedRight);
+
+    // Assert — 伸縮アキが無いので自然高（10, 24, 38）のまま
+    assert_eq!(rule_ys(&pages[0]), vec![10.0, 24.0, 38.0]);
   }
 }

--- a/crates/layout/src/lib.rs
+++ b/crates/layout/src/lib.rs
@@ -76,6 +76,14 @@ const JA_LATIN_AKI_RATIO: f32 = 0.25;
 /// 同オーダーの微小値に抑える。収縮は持たない（四分より詰めない）。
 const JA_LATIN_AKI_STRETCH_RATIO: f32 = 0.05;
 
+/// ブロック間アキ（`VBox::margin_bottom`）の伸長能力（自然値に対する倍率）
+///
+/// 下端揃え（#169）が満杯リージョンの不足高さを配分する重み。各アキが自然値に比例して伸びる
+/// （相対サイズを保つ）ようにするため `stretch = natural × この比率` とする。均一な比率は
+/// `deficit / total_stretch` の分配で相殺され結果に影響しないので値は 1.0 とする。下端揃えが無効なら
+/// `break_pages` は `stretch` を無視するため、この伸長は既定出力を一切変えない。
+const BLOCK_GLUE_STRETCH_RATIO: f32 = 1.0;
+
 /// レイアウトノードを計測済みのブロック列に変換する
 ///
 /// # Arguments
@@ -197,7 +205,10 @@ impl Measurer<'_> {
           let child_right_indent = right_indent + vbox_right_indent.to_pt();
           self.walk_vertical(children, blocks, paragraph, child_indent, child_right_indent, vbox_align);
           self.flush_paragraph(blocks, paragraph, child_indent, child_right_indent, vbox_align);
-          blocks.push(Block::fixed_space(margin_bottom.to_pt()));
+          // ブロック間アキは伸縮 glue にする。下端揃え（#169）が満杯リージョンの不足高さを
+          // 自然値比で配分する。下端揃え無効時は break_pages が stretch を無視するため出力不変。
+          let natural = margin_bottom.to_pt();
+          blocks.push(Block::stretchable_space(natural, natural * BLOCK_GLUE_STRETCH_RATIO));
         },
         LayoutNode::Vkern { length } => {
           self.flush_paragraph(blocks, paragraph, indent, right_indent, align);

--- a/crates/read_style/src/lib.rs
+++ b/crates/read_style/src/lib.rs
@@ -22,6 +22,7 @@ pub mod hyperref;
 pub mod list;
 pub mod math;
 pub mod number_style;
+pub mod page;
 pub mod page_numbering;
 pub mod quote;
 pub mod reference;
@@ -53,6 +54,7 @@ pub use crate::{
   list::ListStyle,
   math::{Alignment, MathBlockStyle, MathScriptStyle, MathStyle, NumberSide},
   number_style::NumberStyle,
+  page::PageStyle,
   page_numbering::PageNumbering,
   quote::QuoteStyle,
   reference::ReferenceStyle,

--- a/crates/read_style/src/page.rs
+++ b/crates/read_style/src/page.rs
@@ -1,0 +1,61 @@
+//! ページ組版の挙動スタイル設定型。
+//!
+//! 「同じ本文 + 同じ用紙で見た目だけ差し替える」対象のうち、段組み（[`crate::columns`]）とは別の
+//! ページ単位の組版挙動を集約する。用紙サイズ・余白は物理設定として `config.toml` 側に残り、本型は
+//! `style.toml`（`[page]`）に置く。実際の組版判断は `hlist::break_pages` が担い、本型はそのフラグだけを保持する。
+
+use garde::Validate;
+use serde::{Deserialize, Serialize};
+
+/// ページ組版の挙動スタイル設定
+///
+/// `flush_bottom` は下端揃え（各ページ・各段の最終ベースラインを版面下端へ揃える）の有効化スイッチ。
+/// 既定 `false`（従来どおりの ragged bottom）。有効時は満杯ページの不足高さを段落間・見出し前後等の
+/// 伸縮アキへ配分する（`hlist::break_pages`）。最終ページ・強制改ページ直前・伸縮アキの無いページは
+/// 揃えない（自然高のまま）。
+#[derive(Debug, Clone, Deserialize, Serialize, Validate)]
+#[garde(allow_unvalidated)]
+#[serde(deny_unknown_fields, default)]
+pub struct PageStyle {
+  /// 下端揃え（flush bottom）を有効にするか（既定 `false`）
+  pub flush_bottom: bool,
+}
+
+impl Default for PageStyle {
+  fn default() -> Self {
+    return Self {
+      flush_bottom: false,
+    };
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use garde::Validate;
+
+  use super::PageStyle;
+
+  #[test]
+  fn validate_accepts_default() {
+    // Arrange / Act / Assert
+    assert!(PageStyle::default().validate().is_ok());
+  }
+
+  #[test]
+  fn default_disables_flush_bottom() {
+    // Arrange / Act
+    let style = PageStyle::default();
+
+    // Assert
+    assert!(!style.flush_bottom);
+  }
+
+  #[test]
+  fn validate_accepts_enabled_flush_bottom() {
+    // Arrange
+    let style = PageStyle { flush_bottom: true };
+
+    // Act / Assert
+    assert!(style.validate().is_ok());
+  }
+}

--- a/crates/read_style/src/style.rs
+++ b/crates/read_style/src/style.rs
@@ -16,6 +16,7 @@ use crate::{
   hyperref::HyperrefStyle,
   list::ListStyle,
   math::MathStyle,
+  page::PageStyle,
   page_numbering::PageNumbering,
   quote::QuoteStyle,
   reference::ReferenceStyle,
@@ -49,6 +50,9 @@ pub struct Style {
   /// 段組み（1 段 / 2 段切替）のスタイル
   #[garde(dive)]
   pub columns: ColumnsStyle,
+  /// ページ組版の挙動（下端揃え等）のスタイル
+  #[garde(dive)]
+  pub page: PageStyle,
   /// リストのスタイル
   #[garde(dive)]
   pub list: ListStyle,
@@ -104,6 +108,7 @@ impl Default for Style {
       heading: HeadingStyles::default(),
       text: TextBlockStyle::default(),
       columns: ColumnsStyle::default(),
+      page: PageStyle::default(),
       list: ListStyle::default(),
       quote: QuoteStyle::default(),
       table: TableStyle::default(),

--- a/crates/read_style/tests/parse.rs
+++ b/crates/read_style/tests/parse.rs
@@ -76,6 +76,39 @@ fn parse_style_columns_defaults_to_single_column() {
 }
 
 #[test]
+fn parse_style_enables_flush_bottom() {
+  // Arrange: [page] で下端揃えを有効化
+  let toml = "[page]\nflush_bottom = true\n";
+
+  // Act
+  let style = parse_style(toml, dummy_source()).unwrap();
+
+  // Assert
+  assert!(style.page.flush_bottom);
+}
+
+#[test]
+fn parse_style_flush_bottom_defaults_to_disabled() {
+  // Arrange / Act: 未指定なら既定で無効（従来どおりの ragged bottom）
+  let style = parse_style("", dummy_source()).unwrap();
+
+  // Assert
+  assert!(!style.page.flush_bottom);
+}
+
+#[test]
+fn parse_style_fails_on_unknown_page_key() {
+  // Arrange: [page] 内の typo は deny_unknown_fields で拒否
+  let toml = "[page]\nflush_botom = true\n";
+
+  // Act
+  let result = parse_style(toml, dummy_source());
+
+  // Assert
+  assert!(result.is_err());
+}
+
+#[test]
 fn parse_style_fails_on_unknown_columns_key() {
   // Arrange: [columns] 内の typo は deny_unknown_fields で拒否
   let toml = "[columns]\ncont = 2\n";

--- a/crates/seiran/src/build_pdf.rs
+++ b/crates/seiran/src/build_pdf.rs
@@ -337,10 +337,13 @@ fn build_page_geometries(
     table_cell_padding: style.table.cell_padding.to_pt(),
     num_columns: body_columns,
     column_gap,
+    flush_bottom: style.page.flush_bottom,
   };
+  // 前付け（タイトルページ・目次）は下端揃えの対象外。struct-update で本文値を継ぐため明示的に落とす。
   let front_geometry = hlist::PageGeometry {
     num_columns: 1,
     column_gap: 0.0,
+    flush_bottom: false,
     ..body_geometry
   };
   return (body_geometry, front_geometry);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,7 +44,7 @@ Document IR の型定義（`Document` / `DocNode` / `InlineNode` / `MathNode` / 
 
 ## `hlist`
 
-フォント非依存のコア型（`HItem` / `HBox` / `Atom` / `Block` / `Line` / `Page` / `GlyphRun` / `TableBox`）と純粋組版パス: (b) `break_opportunities`（ICU UAX #14 に `hyphenation`（`hypher`）の欧文語中分割点＝`BreakKind::Hyphen` を重ねる。言語は `resolve_hyphenation` が BCP 47 から解決）、(c) `break_lines`（`LineBreaker` / `GreedyBreaker`。語中折り返しは `HItem::Discretionary` で表し、折り返した行末だけハイフンを出す）、(d) `break_pages`（ベースライン送り・改ページ・表分割・`PageGeometry`）。表の列幅・行高の純粋計測もここ。
+フォント非依存のコア型（`HItem` / `HBox` / `Atom` / `Block` / `Line` / `Page` / `GlyphRun` / `TableBox`）と純粋組版パス: (b) `break_opportunities`（ICU UAX #14 に `hyphenation`（`hypher`）の欧文語中分割点＝`BreakKind::Hyphen` を重ねる。言語は `resolve_hyphenation` が BCP 47 から解決）、(c) `break_lines`（`LineBreaker` / `GreedyBreaker`。語中折り返しは `HItem::Discretionary` で表し、折り返した行末だけハイフンを出す）、(d) `break_pages`（ベースライン送り・改ページ・表分割・`PageGeometry`）。表の列幅・行高の純粋計測もここ。改ページ制御は glue（伸縮アキ）/ penalty（分割コスト）モデルで、widow/orphan・keep-with-next・下端揃え（`PageGeometry.flush_bottom`）を扱う。下端揃えは満杯リージョン（段）確定時（`advance_region`）に不足高さ `page_limit − 下端` を段内の伸縮アキへ配置順ベースで比例配分する（末尾ページ・強制改ページ直前・伸縮アキ 0 のリージョンは対象外）。
 
 ## `font`
 
@@ -56,7 +56,7 @@ DocNode → LayoutNode への論理変換層（`lib.rs` + `figure` / `float` / `
 
 ## `layout`
 
-(a) `build_blocks`: LayoutNode → `Vec<Block>`。縦リストの再帰的平坦化（`VBox` は副縦リスト）、テキストのスクリプト分割・シェーピング・計測、break 注入（シェーピング後に `GlyphRun` を ICU の分割可能位置で分割。欧文スペースは伸縮 `Glue`、和文字間は幅 0・微小伸長の `Glue`、欧文のスペースなし分割点は `Penalty(0)`、欧文語中のハイフネーション点は計測済みハイフン箱を持つ `Discretionary`（`build_blocks` の `language` 引数から言語を導出。和文・数式は分割しない）。数式は分割しない）、`Raise` ツリーの `Atom` 化。`icu` でスクリプト判定、`font` のシェーパーと `FontMetrics` を利用。`running` サブモジュールの `build_running_content` は `break_pages` 後（ページ数確定後）にヘッダー・フッターをトークン展開・シェーピングして各 `Page::header` / `footer` に `PlacedBlock` として配置する。
+(a) `build_blocks`: LayoutNode → `Vec<Block>`。縦リストの再帰的平坦化（`VBox` は副縦リスト）、テキストのスクリプト分割・シェーピング・計測、break 注入（シェーピング後に `GlyphRun` を ICU の分割可能位置で分割。欧文スペースは伸縮 `Glue`、和文字間は幅 0・微小伸長の `Glue`、欧文のスペースなし分割点は `Penalty(0)`、欧文語中のハイフネーション点は計測済みハイフン箱を持つ `Discretionary`（`build_blocks` の `language` 引数から言語を導出。和文・数式は分割しない）。数式は分割しない）、`Raise` ツリーの `Atom` 化。ブロック間アキ（`VBox::margin_bottom`）は自然値に比例した stretch を持つ縦 `Block::Glue` として出し（下端揃え #169 の配分先）、`Vkern`（数式上下・フロート内）は固定アキのまま。`icu` でスクリプト判定、`font` のシェーパーと `FontMetrics` を利用。`running` サブモジュールの `build_running_content` は `break_pages` 後（ページ数確定後）にヘッダー・フッターをトークン展開・シェーピングして各 `Page::header` / `footer` に `PlacedBlock` として配置する。
 
 ## `pdf_gen`
 


### PR DESCRIPTION
## 概要

満杯ページ／段の不足高さを段内の伸縮アキへ比例配分し、最終ベースラインを版面下端へ揃える下端揃え（flush bottom）を `style.toml` のオプションとして追加する。既定は無効（従来どおりの ragged bottom）。Closes #169。

## 変更内容

- **hlist (`break_pages.rs`)**: `PageGeometry` に `flush_bottom: bool` を追加。`PageComposer` にリージョン（段）追跡 `region_start` / `region_link_start` / `region_anchor_start` / `region_glues` を持たせ、`end_region(flush)` が満杯リージョン確定時に不足高さ `page_limit − 段下端` を段内の伸縮アキへ配分する。
  - **配分は配置順ベース**: 各アキ通過時点の `current` / `current_links` / `current_anchors` の長さを `GlueMark` に記録し、index で「そのアキより後の要素」を厳密に判定する。行の箱がアキ帯へ食い込む座標曖昧さを回避し、行・図・表・数式・リンク矩形・アンカーを一律に下方シフトできる。
  - **末尾アキを分母から除外**: 改段で捨てられる末尾アキを配分対象から外し、末尾ブロックの底辺がちょうど `page_limit` に届くようにする。
  - **flush 発火点は `advance_region` の 1 点に集約**。強制改ページ（`start_new_page` 直呼び）・最終ページ（`finish`）はこの経路を通らず自然にスキップされる。
- **layout (`lib.rs`)**: ブロック間アキ `VBox.margin_bottom` を stretch 付き glue で発行（`stretch = natural`。均一比率は `deficit / total_stretch` の配分で相殺され、各アキが自然値比で伸びる）。`Vkern`（数式上下・フロート内キャプション↔本体）は固定アキのまま剛性を保つ。`Block::stretchable_space` ヘルパを追加。
- **read_style**: `style.toml` に新 `[page]` テーブルと `PageStyle { flush_bottom: bool }`（既定 `false`、`ColumnsStyle` を模倣）を追加。
- **seiran (`build_pdf.rs`)**: 本文ジオメトリは `style.page.flush_bottom`、前付け（タイトル・目次）は常に `false`。

## 設計上の判断

- **配置場所**: issue が保留していたスイッチの配置先は `[page]` テーブル新設に確定（段組み `[columns]` と並ぶページ系グループ。将来のページ制御の受け皿）。
- **リージョン下端はカーソルでなく確定ブロックから算出**: 段落がリージョンをまたぐと `place_paragraph` 中は `composer.y` が stale のため、`current[region_start..]` の各 `PlacedBlock` の底辺の最大値を下端とする。
- **既定出力の不変性**: `break_pages` の glue アームは stretch を無視して `natural` のみ加算し、keep/widow のシミュレーションも `natural` のみ参照するため、アキに stretch を足しても flush 無効時は座標が一切変わらない（golden バイト不変）。

## テスト

- **hlist** 6 本: 不足高さ配分（座標一致）・無効時 ragged・段落行シフト・複数ページ間の下端揃え・強制改ページ直前 skip・伸縮アキ無し skip。
- **read_style** 3 本: `[page] flush_bottom` の parse・既定 false・unknown key 拒否。
- **golden**（`cargo test -p seiran`）: `UPDATE_GOLDEN` 無しで pass（既定出力バイト不変）。
- **e2e**: A4・見出し + 図を含む実 PDF で、有効時に非最終ページ最終行が版面下端（≈785pt）へ寄り（615pt → 783pt）、最終ページは不変、ページ数は有無で不変（2/2）を確認。
- `cargo test` 全 pass ／ `cargo clippy --all-targets` 0 warning ／ `cargo +nightly fmt --check` clean。

## スコープ外

- 段落間・見出し前後アキの stretch 量の `style.toml` 公開（現状は自然値比の固定）。
- 脚注のページ下部予約（epic #22）・フロート配置（#111）。

## 関連

Closes #169 ／ epic #165（#166 モデル移行・#167 widow/orphan・#168 keep-with-next の上に積む 4 番目のタスク）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)