### PR TITLE
組版: ページ番号・総ページ数の解決を明示 2 段階モデルへ一本化

### DIFF
--- a/crates/seiran/src/build_pdf.rs
+++ b/crates/seiran/src/build_pdf.rs
@@ -5,6 +5,7 @@
 mod error;
 mod front_matter;
 mod outline;
+mod page_values;
 mod running;
 
 #[cfg(test)]
@@ -24,14 +25,14 @@ use font::{
   shaper::{HarfRustShapers, HarfRustShapersExt, ShaperDatas, ShaperDatasExt, ShaperInstances, ShaperInstancesExt},
   validate_font,
 };
-use front_matter::{assemble_front_matter, break_front_matter, page_number_labels};
+use front_matter::{assemble_front_matter, break_front_matter};
 use lowering::LoweringContext;
 use outline::collect_outline_entries;
+use page_values::BodyPageValues;
 use parser::ParseSourceError;
 use pdf_gen::OutlineEntry;
 use running::build_running_spec;
 use tracing::{debug, debug_span, info};
-use types::AnchorMark;
 
 /// ビルド成功時のサマリ（ユーザーチャンネルのレポータが表示する最小情報）
 ///
@@ -237,7 +238,7 @@ fn build_pages(
     hlist::break_pages(body_blocks, text_width, &body_geometry, &hlist::KnuthPlassBreaker, style.text.alignment)
   };
   let body_page_count = body_pages.len();
-  let heading_pages = heading_page_indices(&body_pages);
+  let body_page_values = BodyPageValues::from_body_pages(&body_pages, &style.page_numbering);
   info!(body_page_count, elapsed_ms = elapsed_ms(stage_start), "本文のページ分割が完了しました");
 
   // 前付けブロック（タイトルページ → 目次）を組み立てる。各リージョンは改ページ境界で始まる。
@@ -247,8 +248,15 @@ fn build_pages(
     author: config.document.author.clone(),
     date: config.document.date.clone(),
   };
-  let front_blocks =
-    assemble_front_matter(&headings, &heading_pages, &title_metadata, style, &harf_rust_shapers, &metrics, text_width);
+  let front_blocks = assemble_front_matter(
+    &headings,
+    &body_page_values,
+    &title_metadata,
+    style,
+    &harf_rust_shapers,
+    &metrics,
+    text_width,
+  );
 
   // 前付け（1 段）を本文（N 段）と別に分割し、ページ列として連結する。前付けと本文は段数が異なるため
   // 1 回の break_pages では兼ねられない。連結することで本文ページは後ろの index へ自動的にずれ、内部
@@ -259,8 +267,11 @@ fn build_pages(
     break_front_matter(front_blocks, text_width, &front_geometry, &hlist::KnuthPlassBreaker, style.text.alignment)
   };
   let front_matter_count = front_pages.len();
+  // 前付けページ列が確定した時点（`pages` への move の前）でラベルを解決する。
+  let page_labels = body_page_values.finalize(&front_pages);
   let mut pages = front_pages;
   pages.extend(body_pages);
+  debug_assert_eq!(page_labels.len(), pages.len(), "ラベル数は物理ページ総数と一致するはず");
   info!(
     page_count = pages.len(),
     front_matter_count,
@@ -269,12 +280,9 @@ fn build_pages(
     "ページ分割が完了しました"
   );
 
-  // ページ番号ラベルを算出する（前付け = ローマ数字 / 本文 = 算用数字、各リージョン 1 から）。
-  let page_numbers = page_number_labels(pages.len(), front_matter_count, body_page_count, &style.page_numbering);
-
   // ページ数確定後にヘッダー・フッターを配置する（ページ番号トークンの解決にラベルが必要なため）
   let page_height = config.pdf.height;
-  let running_spec = build_running_spec(style, &config.document, text_width, page_height, page_numbers);
+  let running_spec = build_running_spec(style, &config.document, text_width, page_height, page_labels);
   layout::build_running_content(&mut pages, &harf_rust_shapers, &metrics, &running_spec);
 
   // PDF しおり用の見出し情報を文書順に集める（CSL 整形で追加された References 見出しも含む）。
@@ -394,70 +402,9 @@ fn build_page_geometries(
   return (body_geometry, front_geometry);
 }
 
-/// 本文 Pass のページ列から、各見出しの本文内ページ index を文書順に採取する。
-///
-/// `pdf_gen::build_destination_index` と同型のアンカー走査。`document::collect_headings` が返す
-/// 見出し列と 1 対 1 に対応する（どちらも文書順）。
-fn heading_page_indices(pages: &[hlist::Page]) -> Vec<usize> {
-  let mut indices = Vec::new();
-  for (page_index, page) in pages.iter().enumerate() {
-    for anchor in &page.anchors {
-      if matches!(anchor.mark, AnchorMark::Heading { .. }) {
-        indices.push(page_index);
-      }
-    }
-  }
-  return indices;
-}
-
 #[cfg(test)]
 mod tests {
-  use hlist::{Page, PlacedAnchor};
-  use types::AnchorMark;
-
-  use super::{BuildPdfError, ParsedSource, heading_page_indices, wrap_lowering_error};
-
-  /// 指定マークのアンカーだけを持つページを作るヘルパ
-  fn page_with_anchors(marks: Vec<AnchorMark>) -> Page {
-    return Page {
-      blocks: Vec::new(),
-      header: Vec::new(),
-      footer: Vec::new(),
-      anchors: marks
-        .into_iter()
-        .map(|mark| PlacedAnchor {
-          mark,
-          x: types::Length::ZERO,
-          y: types::Length::ZERO,
-        })
-        .collect(),
-      links: Vec::new(),
-    };
-  }
-
-  #[test]
-  fn heading_page_indices_picks_heading_anchors_in_order() {
-    // Arrange — page0 に見出し 1 つ、page1 に Label（無視）+ 見出し 1 つ
-    let pages = vec![
-      page_with_anchors(vec![AnchorMark::Heading {
-        key: "heading:0".to_string(),
-        label: None,
-      }]),
-      page_with_anchors(vec![
-        AnchorMark::Label("tab:1".to_string()),
-        AnchorMark::Heading {
-          key: "heading:1".to_string(),
-          label: None,
-        },
-      ]),
-    ];
-
-    // Act
-    let indices = heading_page_indices(&pages);
-
-    // Assert — 見出しアンカーのページ index だけを文書順に拾う（Label は無視）
-    assert_eq!(indices, vec![0, 1]);
-  }
+  use super::{BuildPdfError, ParsedSource, wrap_lowering_error};
 
   /// index=1 のグループに未定義ラベルの `\ref` を含む 2 グループを作り、`source_id()==1` の
   /// `LoweringError` を生成するテストヘルパ

--- a/crates/seiran/src/build_pdf/front_matter.rs
+++ b/crates/seiran/src/build_pdf/front_matter.rs
@@ -5,9 +5,11 @@ use font::{FontMetrics, shaper::HarfRustShapers};
 use hlist::{Block, LineBreaker, Page, PageGeometry};
 use layout::{TocEntryInput, TocSpec, build_blocks, build_toc_blocks};
 use lowering::{HeadingRecord, TextStyle, TitlePageMetadata, lower_title_page};
-use read_style::{PageNumbering, Style, TocStyle};
+use read_style::{Style, TocStyle};
 use tracing::{debug, debug_span};
 use types::{FontKind, HeadingLevel, TextAlignment};
+
+use super::page_values::BodyPageValues;
 
 /// 前付けブロック（タイトルページ → 目次）を文書順に組み立てて返す。
 ///
@@ -16,7 +18,7 @@ use types::{FontKind, HeadingLevel, TextAlignment};
 /// 始める（本文区間の独立性を保つ）。`title_page` / `toc` がともに無効なら空列を返す。
 pub(super) fn assemble_front_matter(
   headings: &[HeadingRecord],
-  heading_pages: &[usize],
+  page_values: &BodyPageValues,
   title_metadata: &TitlePageMetadata,
   style: &Style,
   shapers: &HarfRustShapers,
@@ -45,7 +47,7 @@ pub(super) fn assemble_front_matter(
     debug!("タイトルページを生成しました");
   }
   if style.toc.enabled {
-    let toc_entries = collect_toc_entries(headings, heading_pages, &style.toc, &style.page_numbering);
+    let toc_entries = collect_toc_entries(headings, page_values, &style.toc);
     let toc_spec = build_toc_spec(style, text_width);
     let toc_blocks = build_toc_blocks(&toc_spec, &toc_entries, shapers, metrics);
     if !toc_blocks.is_empty() {
@@ -59,15 +61,11 @@ pub(super) fn assemble_front_matter(
 
 /// 見出しと本文内ページ index から目次エントリ列を組み立てる。
 ///
-/// `max_depth` を超える深さの見出しは除外する。ページラベルは本文の番号スタイル（算用数字）で
-/// レンダリングし、内部リンクキーは見出しの文書順インデックスから [`document::heading_anchor_key`]
-/// で得る（lowering 側の `AnchorMark::Heading.key` と一致する）。
-fn collect_toc_entries(
-  headings: &[HeadingRecord],
-  heading_pages: &[usize],
-  toc: &TocStyle,
-  page_numbering: &PageNumbering,
-) -> Vec<TocEntryInput> {
+/// `max_depth` を超える深さの見出しは除外する。ページラベルは [`BodyPageValues::body_page_label`]
+/// （本文の番号スタイル＝算用数字）でレンダリングし、内部リンクキーは見出しの文書順インデックスから
+/// [`document::heading_anchor_key`] で得る（lowering 側の `AnchorMark::Heading.key` と一致する）。
+fn collect_toc_entries(headings: &[HeadingRecord], page_values: &BodyPageValues, toc: &TocStyle) -> Vec<TocEntryInput> {
+  let heading_pages = page_values.heading_pages();
   debug_assert_eq!(headings.len(), heading_pages.len(), "見出し数と採取したページ数は一致するはず");
   return headings
     .iter()
@@ -77,7 +75,7 @@ fn collect_toc_entries(
       level: info.level,
       number: info.number.clone(),
       title_plain: info.title_plain.clone(),
-      page_label: page_numbering.body.render(page_index as u32 + 1),
+      page_label: page_values.body_page_label(page_index),
       link_key: heading_anchor_key(info.index),
     })
     .collect();
@@ -133,40 +131,14 @@ pub(super) fn break_front_matter(
   return hlist::break_pages(front_blocks, text_width, front_geometry, breaker, alignment);
 }
 
-/// 各物理ページの `(\{page\}, \{pages\})` ラベルをリージョン別に算出する。
-///
-/// 前付け（index `< front_count`）は `page_numbering.front_matter`（既定ローマ数字）で 1 から、
-/// 本文はそれ以降を `page_numbering.body`（既定算用数字）で 1 から振り直す。`\{pages\}` は同じ
-/// リージョンの総数を同じスタイルでレンダリングしたもの。
-pub(super) fn page_number_labels(
-  total: usize,
-  front_count: usize,
-  body_count: usize,
-  page_numbering: &PageNumbering,
-) -> Vec<(String, String)> {
-  let mut labels = Vec::with_capacity(total);
-  for index in 0..total {
-    if index < front_count {
-      let page = page_numbering.front_matter.render(index as u32 + 1);
-      let pages = page_numbering.front_matter.render(front_count as u32);
-      labels.push((page, pages));
-    } else {
-      let body_index = index - front_count;
-      let page = page_numbering.body.render(body_index as u32 + 1);
-      let pages = page_numbering.body.render(body_count as u32);
-      labels.push((page, pages));
-    }
-  }
-  return labels;
-}
-
 #[cfg(test)]
 mod tests {
+  use hlist::PlacedAnchor;
   use lowering::HeadingRecord;
   use read_style::{PageNumbering, TocStyle};
-  use types::HeadingLevel;
+  use types::{AnchorMark, HeadingLevel};
 
-  use super::{collect_toc_entries, page_number_labels};
+  use super::{BodyPageValues, Page, collect_toc_entries};
 
   fn heading_record(index: usize, level: HeadingLevel, number: &str, title_plain: &str) -> HeadingRecord {
     return HeadingRecord {
@@ -177,27 +149,25 @@ mod tests {
     };
   }
 
-  #[test]
-  fn page_number_labels_roman_front_arabic_body() {
-    // Arrange — 既定（前付け=ローマ小文字 / 本文=算用）。total=5, front=2, body=3
-    let pn = PageNumbering::default();
-
-    // Act
-    let labels = page_number_labels(5, 2, 3, &pn);
-
-    // Assert — 前付けは i, ii（総数 ii）、本文は 1..3（総数 3）でリージョン別に振り直す
-    assert_eq!(labels[0], ("i".to_string(), "ii".to_string()));
-    assert_eq!(labels[1], ("ii".to_string(), "ii".to_string()));
-    assert_eq!(labels[2], ("1".to_string(), "3".to_string()));
-    assert_eq!(labels[4], ("3".to_string(), "3".to_string()));
-  }
-
-  #[test]
-  fn page_number_labels_without_front_matter_is_plain_arabic() {
-    // 前付けが無ければ全ページが本文系列（算用数字 1 から）= 従来挙動
-    let labels = page_number_labels(3, 0, 3, &PageNumbering::default());
-    assert_eq!(labels[0].0, "1");
-    assert_eq!(labels[2], ("3".to_string(), "3".to_string()));
+  /// 各ページに 1 つずつ見出しアンカーを持つ本文ページ列から [`BodyPageValues`] を作るヘルパ
+  fn body_page_values_with_headings(heading_count: usize) -> BodyPageValues {
+    let pages: Vec<Page> = (0..heading_count)
+      .map(|index| Page {
+        blocks: Vec::new(),
+        header: Vec::new(),
+        footer: Vec::new(),
+        anchors: vec![PlacedAnchor {
+          mark: AnchorMark::Heading {
+            key: format!("heading:{index}"),
+            label: None,
+          },
+          x: types::Length::ZERO,
+          y: types::Length::ZERO,
+        }],
+        links: Vec::new(),
+      })
+      .collect();
+    return BodyPageValues::from_body_pages(&pages, &PageNumbering::default());
   }
 
   #[test]
@@ -208,14 +178,14 @@ mod tests {
       heading_record(1, HeadingLevel::Section, "1.1", "Sec"),
       heading_record(2, HeadingLevel::Subsection, "1.1.1", "Sub"),
     ];
-    let heading_pages = vec![0, 1, 2];
+    let page_values = body_page_values_with_headings(3);
     let toc = TocStyle {
       max_depth: 3,
       ..TocStyle::default()
     };
 
     // Act
-    let entries = collect_toc_entries(&headings, &heading_pages, &toc, &PageNumbering::default());
+    let entries = collect_toc_entries(&headings, &page_values, &toc);
 
     // Assert — Subsection は除外、ページラベルは本文算用数字、リンクキーは文書順インデックス由来
     assert_eq!(entries.len(), 2);

--- a/crates/seiran/src/build_pdf/page_values.rs
+++ b/crates/seiran/src/build_pdf/page_values.rs
@@ -1,0 +1,200 @@
+//! ページ分割後に確定する値（ページ番号・総ページ数）の解決機構
+//!
+//! ページ番号・総ページ数はページ分割（`hlist::break_pages`）が終わるまで確定しない。目次と
+//! running content（ヘッダー・フッター）はこの確定値をそれぞれ異なる時点で必要とするため、
+//! その順序制約を型で表す 2 段階に分ける。
+//!
+//! - Stage 1 [`BodyPageValues`]: 本文ページ列からしか構築できない（目次構築の引数型）
+//! - Stage 2 [`PageLabels`]: `finalize`（前付けページ列確定）後にしか得られない（running の引数型）
+//!
+//! lowering の pass1/pass2（`LayoutNode::Ref` → `resolve_refs`）と同じ「確定後に別走査で解決する」
+//! 流儀を型に昇格させたもの。
+
+use read_style::PageNumbering;
+use types::AnchorMark;
+
+/// 本文ページ分割後にしか構築できない確定値（目次構築の引数型）
+///
+/// 見出しの本文内ページ index とページ番号スタイルを保持する。目次のページラベルは本文の
+/// break 完了時点ですでに確定している（本文ページ番号は前付け長に不依存 = R1）ため、
+/// このステージだけで [`Self::body_page_label`] によるレンダリングが可能。
+pub(super) struct BodyPageValues {
+  /// 見出し → 本文内ページ index（文書順）
+  heading_pages: Vec<usize>,
+  /// 本文ページの総数
+  body_page_count: usize,
+  /// ページ番号のスタイル設定（クローン所有。借用にするとライフタイムが波及するため）
+  numbering: PageNumbering,
+}
+
+impl BodyPageValues {
+  /// 本文ページ列とページ番号スタイルから [`BodyPageValues`] を構築する。
+  ///
+  /// `pdf_gen::build_destination_index` と同型のアンカー走査で、各ページの `AnchorMark::Heading`
+  /// アンカーだけを文書順に拾う（`AnchorMark::Label` は無視）。
+  pub(super) fn from_body_pages(body_pages: &[hlist::Page], numbering: &PageNumbering) -> Self {
+    let mut heading_pages = Vec::new();
+    for (page_index, page) in body_pages.iter().enumerate() {
+      for anchor in &page.anchors {
+        if matches!(anchor.mark, AnchorMark::Heading { .. }) {
+          heading_pages.push(page_index);
+        }
+      }
+    }
+    return Self {
+      heading_pages,
+      body_page_count: body_pages.len(),
+      numbering: numbering.clone(),
+    };
+  }
+
+  /// 見出し → 本文内ページ index の列（文書順）を返す。
+  pub(super) fn heading_pages(&self) -> &[usize] { return &self.heading_pages; }
+
+  /// 本文内ページ index（0 起点）から、本文の番号スタイル（1 起点）でレンダリングしたラベルを返す。
+  ///
+  /// 目次のページラベル用。前付けのラベル体系（[`Self::finalize`]）とは独立に、本文スタイルだけで
+  /// 確定できる。
+  pub(super) fn body_page_label(&self, body_page_index: usize) -> String {
+    return self.numbering.body.render(body_page_index as u32 + 1);
+  }
+
+  /// 前付けページ列が確定した後、物理ページ順の `({page}, {pages})` ラベル列 [`PageLabels`] を返す。
+  ///
+  /// 前付け（index `< front_pages.len()`）は `numbering.front_matter`（既定ローマ数字）で 1 から、
+  /// 本文はそれ以降を `numbering.body`（既定算用数字）で 1 から振り直す。`{pages}` は同じリージョンの
+  /// 総数を同じスタイルでレンダリングしたもの。素の `usize` でなく前付けページ列そのものを引数に取る
+  /// ことで、「連結前の前付けページ列が確定していること」を型で要求する（0 や本文数の誤渡しを防ぐ）。
+  pub(super) fn finalize(self, front_pages: &[hlist::Page]) -> PageLabels {
+    let front_count = front_pages.len();
+    let body_count = self.body_page_count;
+    let total = front_count + body_count;
+    let mut labels = Vec::with_capacity(total);
+    for index in 0..total {
+      if index < front_count {
+        let page = self.numbering.front_matter.render(index as u32 + 1);
+        let pages = self.numbering.front_matter.render(front_count as u32);
+        labels.push((page, pages));
+      } else {
+        let body_index = index - front_count;
+        let page = self.numbering.body.render(body_index as u32 + 1);
+        let pages = self.numbering.body.render(body_count as u32);
+        labels.push((page, pages));
+      }
+    }
+    return PageLabels { labels };
+  }
+}
+
+/// 前付けページ列確定後にしか得られない、物理ページ順の `({page}, {pages})` ラベル列（running の引数型）
+pub(super) struct PageLabels {
+  labels: Vec<(String, String)>,
+}
+
+impl PageLabels {
+  /// ラベル総数（物理ページ総数と一致するはず）。`build_pages` の `debug_assert` 用。
+  pub(super) fn len(&self) -> usize { return self.labels.len(); }
+
+  /// `layout::RunningContentSpec::page_numbers` へ渡すため、所有権ごと `Vec` に変換する。
+  pub(super) fn into_vec(self) -> Vec<(String, String)> { return self.labels; }
+}
+
+#[cfg(test)]
+mod tests {
+  use hlist::{Page, PlacedAnchor};
+  use read_style::PageNumbering;
+  use types::AnchorMark;
+
+  use super::BodyPageValues;
+
+  /// 指定マークのアンカーだけを持つページを作るヘルパ
+  fn page_with_anchors(marks: Vec<AnchorMark>) -> Page {
+    return Page {
+      blocks: Vec::new(),
+      header: Vec::new(),
+      footer: Vec::new(),
+      anchors: marks
+        .into_iter()
+        .map(|mark| PlacedAnchor {
+          mark,
+          x: types::Length::ZERO,
+          y: types::Length::ZERO,
+        })
+        .collect(),
+      links: Vec::new(),
+    };
+  }
+
+  #[test]
+  fn from_body_pages_picks_heading_anchors_in_order() {
+    // Arrange — page0 に見出し 1 つ、page1 に Label（無視）+ 見出し 1 つ
+    let pages = vec![
+      page_with_anchors(vec![AnchorMark::Heading {
+        key: "heading:0".to_string(),
+        label: None,
+      }]),
+      page_with_anchors(vec![
+        AnchorMark::Label("tab:1".to_string()),
+        AnchorMark::Heading {
+          key: "heading:1".to_string(),
+          label: None,
+        },
+      ]),
+    ];
+
+    // Act
+    let page_values = BodyPageValues::from_body_pages(&pages, &PageNumbering::default());
+
+    // Assert — 見出しアンカーのページ index だけを文書順に拾う（Label は無視）
+    assert_eq!(page_values.heading_pages(), &[0, 1]);
+  }
+
+  #[test]
+  fn body_page_label_renders_with_body_style() {
+    // Arrange — 既定は前付け=ローマ小文字 / 本文=算用数字
+    let page_values = BodyPageValues::from_body_pages(&[], &PageNumbering::default());
+
+    // Act
+    let label = page_values.body_page_label(0);
+
+    // Assert — 本文スタイル（算用数字）でレンダリングされ、前付けのローマ数字にはならない
+    assert_eq!(label, "1");
+  }
+
+  #[test]
+  fn finalize_roman_front_arabic_body() {
+    // Arrange — 既定（前付け=ローマ小文字 / 本文=算用）。前付け 2 ページ、本文 3 ページ
+    let front_pages = vec![page_with_anchors(vec![]), page_with_anchors(vec![])];
+    let body_pages = vec![
+      page_with_anchors(vec![]),
+      page_with_anchors(vec![]),
+      page_with_anchors(vec![]),
+    ];
+    let page_values = BodyPageValues::from_body_pages(&body_pages, &PageNumbering::default());
+
+    // Act
+    let labels = page_values.finalize(&front_pages).into_vec();
+
+    // Assert — 前付けは i, ii（総数 ii）、本文は 1..3（総数 3）でリージョン別に振り直す
+    assert_eq!(labels[0], ("i".to_string(), "ii".to_string()));
+    assert_eq!(labels[1], ("ii".to_string(), "ii".to_string()));
+    assert_eq!(labels[2], ("1".to_string(), "3".to_string()));
+    assert_eq!(labels[4], ("3".to_string(), "3".to_string()));
+  }
+
+  #[test]
+  fn finalize_without_front_matter_is_plain_arabic() {
+    // 前付けが無ければ全ページが本文系列（算用数字 1 から）= 従来挙動
+    let body_pages = vec![
+      page_with_anchors(vec![]),
+      page_with_anchors(vec![]),
+      page_with_anchors(vec![]),
+    ];
+    let page_values = BodyPageValues::from_body_pages(&body_pages, &PageNumbering::default());
+
+    let labels = page_values.finalize(&[]).into_vec();
+
+    assert_eq!(labels[0].0, "1");
+    assert_eq!(labels[2], ("3".to_string(), "3".to_string()));
+  }
+}

--- a/crates/seiran/src/build_pdf/running.rs
+++ b/crates/seiran/src/build_pdf/running.rs
@@ -5,16 +5,20 @@ use read_config::DocumentConfig;
 use read_style::{RunningContentStyle, Style};
 use types::Color;
 
+use super::page_values::PageLabels;
+
 /// ページ数確定後のヘッダー・フッター配置仕様 [`layout::RunningContentSpec`] を組み立てる。
 ///
 /// ヘッダー / フッターの各スロットは [`running_slots`] で構築し（全スロット空なら描画省略）、`skip_first`
-/// でタイトルページ（先頭ページ）への非描画を指示する。`page_numbers` のラベル解決は配置パス側が担う。
+/// でタイトルページ（先頭ページ）への非描画を指示する。`page_labels` を要求することで、前付けページ列が
+/// 確定した後（[`PageLabels`] は `BodyPageValues::finalize` を経由してしか作れない）にしか呼べないという
+/// 順序制約を型で表す。ラベルのトークン置換自体は配置パス側が担う。
 pub(super) fn build_running_spec(
   style: &Style,
   document: &DocumentConfig,
   text_width: types::Length,
   page_height: types::Length,
-  page_numbers: Vec<(String, String)>,
+  page_labels: PageLabels,
 ) -> RunningContentSpec {
   return RunningContentSpec {
     header: running_slots(&style.header, style.header.baseline_offset, true),
@@ -25,7 +29,7 @@ pub(super) fn build_running_spec(
       date: document.date.clone().unwrap_or_default(),
     },
     text_width,
-    page_numbers,
+    page_numbers: page_labels.into_vec(),
     // タイトルページ（先頭ページ）にはヘッダー・フッターを描画しない
     skip_first: style.title_page.enabled,
   };


### PR DESCRIPTION
## 概要

ページ分割後にしか確定しない値（ページ番号・総ページ数）の解決を、機能ごとの ad-hoc 後段パスから明示 2 段階モデルへ一本化する。Closes #193

## 変更内容

新規 `crates/seiran/src/build_pdf/page_values.rs` に型 2 つを追加:

- `BodyPageValues`（Stage 1）: 本文ページ列とページ番号スタイルから構築（`BodyPageValues::from_body_pages`）。旧 `build_pdf.rs::heading_page_indices` を吸収し、`body_page_label` で目次用ラベルをレンダリング
- `PageLabels`（Stage 2）: `BodyPageValues::finalize(front_pages)` で前付けページ列確定後にのみ得られる。旧 `front_matter.rs::page_number_labels` を吸収

呼び出し側の切り替え:

- `build_pdf.rs::build_pages` — `heading_page_indices` 呼び出しを `BodyPageValues::from_body_pages` に、`page_number_labels` 呼び出しを `body_page_values.finalize(&front_pages)`（`pages` への move 前）に置換。`debug_assert_eq!(page_labels.len(), pages.len())` を追加
- `front_matter.rs::assemble_front_matter` / `collect_toc_entries` — 引数を `heading_pages: &[usize]` → `page_values: &BodyPageValues` に変更。目次のページラベル即席レンダリングを `page_values.body_page_label(...)` に置換
- `running.rs::build_running_spec` — 引数を `page_numbers: Vec<(String, String)>` → `page_labels: PageLabels` に変更

`layout` クレートの公開 API（`RunningContentSpec` / `TocEntryInput`）・`hlist` / `read_style` / `pdf_gen` / dump 形式・golden ファイルは無変更。

## 設計上の判断

「未確定スロット + 流し込みパス」方式は採らなかった。running はラベル幅がスロット位置計算に効き、目次はリーダー充填に効くため、流し込みが再レイアウトを抱え込む。加えて本文ページ番号は前付け長に不依存（R1）なので目次の値は構築時点で確定済みであり、スロットは人工的になる。lowering の pass1/pass2（`LayoutNode::Ref` → `resolve_refs`）と同じ「確定後に別走査で解決する」流儀を型に昇格させた。

`finalize` は素の `usize` でなく前付けページ列 `&[hlist::Page]` を受ける形にし、「連結前の前付けページ列が確定していること」を型で要求する（0 や本文数の誤渡しがコンパイルを通らないようにする）。

## テスト

`page_values.rs` にユニットテスト 4 本を新規実装（旧 `build_pdf.rs` / `front_matter.rs` から移設・適合分含む）。`cargo test --workspace` / `cargo clippy --workspace --all-targets` / `cargo +nightly fmt` すべてパス。`git status` で `tests/golden/` 無変更を確認済み（`title_page` fixture が running content 経路、`toc` fixture が目次経路をそれぞれエンドツーエンドでカバー）。振る舞い不変。

## スコープ外

`\pageref`（前方参照）・索引（#33）・脚注（#22）への拡張はこの PR に含めない。

## 関連

Closes #193